### PR TITLE
Add StreamNameAttribute and corresponding unit tests for validation

### DIFF
--- a/src/framework/EventSourcing.Abstractions.Tests/Attributes/StreamNameAttributeTests.cs
+++ b/src/framework/EventSourcing.Abstractions.Tests/Attributes/StreamNameAttributeTests.cs
@@ -1,0 +1,212 @@
+using Mississippi.EventSourcing.Abstractions.Attributes;
+
+
+namespace Mississippi.EventSourcing.Abstractions.Tests.Attributes;
+
+/// <summary>
+///     Contains unit tests that verify the behaviour of the <see cref="StreamNameAttribute" /> class.
+/// </summary>
+public class StreamNameAttributeTests
+{
+    /// <summary>
+    ///     Verifies that the constructor assigns the supplied parameters to the corresponding
+    ///     properties when all arguments are valid.
+    /// </summary>
+    [Fact]
+    public void ConstructorValidParametersSetsPropertiesCorrectly()
+    {
+        const string appName = "APP";
+        const string moduleName = "MODULE";
+        const string name = "STREAM";
+        StreamNameAttribute sut = new(appName, moduleName, name);
+        Assert.Equal(appName, sut.AppName);
+        Assert.Equal(moduleName, sut.ModuleName);
+        Assert.Equal(name, sut.Name);
+        Assert.Equal("APP.MODULE.STREAM", sut.StreamName);
+    }
+
+    /// <summary>
+    ///     Ensures that the constructor throws an <see cref="ArgumentException" /> when the
+    ///     <paramref name="appName" /> argument is <see langword="null" />, empty or consists only of
+    ///     whitespace characters.
+    /// </summary>
+    /// <param name="appName">The application name to validate.</param>
+    /// <param name="moduleName">The module name supplied to the constructor (ignored for this test).</param>
+    /// <param name="name">The stream name supplied to the constructor (ignored for this test).</param>
+    [Theory]
+    [InlineData(null, "MODULE", "STREAM")]
+    [InlineData("", "MODULE", "STREAM")]
+    [InlineData(" ", "MODULE", "STREAM")]
+    public void ConstructorNullOrEmptyAppNameThrowsArgumentException(
+        string? appName,
+        string moduleName,
+        string name
+    )
+    {
+        ArgumentException ex =
+            Assert.Throws<ArgumentException>(() => new StreamNameAttribute(appName!, moduleName, name));
+        Assert.Equal("appName", ex.ParamName);
+    }
+
+    /// <summary>
+    ///     Ensures that the constructor throws an <see cref="ArgumentException" /> when the
+    ///     <paramref name="moduleName" /> argument is <see langword="null" />, empty or consists only of
+    ///     whitespace characters.
+    /// </summary>
+    /// <param name="appName">The application name supplied to the constructor (ignored for this test).</param>
+    /// <param name="moduleName">The module name to validate.</param>
+    /// <param name="name">The stream name supplied to the constructor (ignored for this test).</param>
+    [Theory]
+    [InlineData("APP", null, "STREAM")]
+    [InlineData("APP", "", "STREAM")]
+    [InlineData("APP", " ", "STREAM")]
+    public void ConstructorNullOrEmptyModuleNameThrowsArgumentException(
+        string appName,
+        string? moduleName,
+        string name
+    )
+    {
+        ArgumentException ex =
+            Assert.Throws<ArgumentException>(() => new StreamNameAttribute(appName, moduleName!, name));
+        Assert.Equal("moduleName", ex.ParamName);
+    }
+
+    /// <summary>
+    ///     Ensures that the constructor throws an <see cref="ArgumentException" /> when the
+    ///     <paramref name="name" /> argument is <see langword="null" />, empty or consists only of
+    ///     whitespace characters.
+    /// </summary>
+    /// <param name="appName">The application name supplied to the constructor (ignored for this test).</param>
+    /// <param name="moduleName">The module name supplied to the constructor (ignored for this test).</param>
+    /// <param name="name">The stream name to validate.</param>
+    [Theory]
+    [InlineData("APP", "MODULE", null)]
+    [InlineData("APP", "MODULE", "")]
+    [InlineData("APP", "MODULE", " ")]
+    public void ConstructorNullOrEmptyNameThrowsArgumentException(
+        string appName,
+        string moduleName,
+        string? name
+    )
+    {
+        ArgumentException ex =
+            Assert.Throws<ArgumentException>(() => new StreamNameAttribute(appName, moduleName, name!));
+        Assert.Equal("name", ex.ParamName);
+    }
+
+    /// <summary>
+    ///     Ensures that the constructor throws an <see cref="ArgumentException" /> when the
+    ///     <paramref name="appName" /> argument does not match the required formatting rules.
+    /// </summary>
+    /// <param name="appName">An invalid application name.</param>
+    [Theory]
+    [InlineData("app")]
+    [InlineData("App")]
+    [InlineData("APP123!")]
+    public void ConstructorInvalidAppNameFormatThrowsArgumentException(
+        string appName
+    )
+    {
+        ArgumentException ex =
+            Assert.Throws<ArgumentException>(() => new StreamNameAttribute(appName, "MODULE", "STREAM"));
+        Assert.Equal("appName", ex.ParamName);
+    }
+
+    /// <summary>
+    ///     Ensures that the constructor throws an <see cref="ArgumentException" /> when the
+    ///     <paramref name="moduleName" /> argument does not match the required formatting rules.
+    /// </summary>
+    /// <param name="moduleName">An invalid module name.</param>
+    [Theory]
+    [InlineData("module")]
+    [InlineData("Module")]
+    [InlineData("MODULE123!")]
+    public void ConstructorInvalidModuleNameFormatThrowsArgumentException(
+        string moduleName
+    )
+    {
+        ArgumentException ex =
+            Assert.Throws<ArgumentException>(() => new StreamNameAttribute("APP", moduleName, "STREAM"));
+        Assert.Equal("moduleName", ex.ParamName);
+    }
+
+    /// <summary>
+    ///     Ensures that the constructor throws an <see cref="ArgumentException" /> when the
+    ///     <paramref name="name" /> argument does not match the required formatting rules.
+    /// </summary>
+    /// <param name="name">An invalid stream name.</param>
+    [Theory]
+    [InlineData("stream")]
+    [InlineData("Stream")]
+    [InlineData("STREAM123!")]
+    public void ConstructorInvalidNameFormatThrowsArgumentException(
+        string name
+    )
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => new StreamNameAttribute("APP", "MODULE", name));
+        Assert.Equal("name", ex.ParamName);
+    }
+
+    /// <summary>
+    ///     Verifies that alphanumeric values are accepted and correctly applied to the attribute
+    ///     properties and the generated stream name.
+    /// </summary>
+    /// <param name="appName">The application name to test.</param>
+    /// <param name="moduleName">The module name to test.</param>
+    /// <param name="name">The stream name to test.</param>
+    [Theory]
+    [InlineData("APP123", "MODULE456", "STREAM789")]
+    [InlineData("A", "M", "S")]
+    [InlineData("1APP", "2MOD", "3STR")]
+    public void ConstructorValidAlphanumericParametersSetsPropertiesCorrectly(
+        string appName,
+        string moduleName,
+        string name
+    )
+    {
+        StreamNameAttribute sut = new(appName, moduleName, name);
+        Assert.Equal(appName, sut.AppName);
+        Assert.Equal(moduleName, sut.ModuleName);
+        Assert.Equal(name, sut.Name);
+        Assert.Equal($"{appName}.{moduleName}.{name}", sut.StreamName);
+    }
+
+    /// <summary>
+    ///     Confirms that component strings consisting solely of digits or prefixed by digits are still
+    ///     treated as valid and correctly formatted.
+    /// </summary>
+    /// <param name="appName">An application component consisting of, or starting with, digits.</param>
+    /// <param name="moduleName">A module component consisting of, or starting with, digits.</param>
+    /// <param name="name">A stream name component consisting of, or starting with, digits.</param>
+    [Theory]
+    [InlineData("123", "456", "789")]
+    [InlineData("1APP", "2MOD", "3STR")]
+    public void ConstructorDigitsOnlyOrPrefixedStillValid(
+        string appName,
+        string moduleName,
+        string name
+    )
+    {
+        StreamNameAttribute sut = new(appName, moduleName, name);
+        Assert.Equal($"{appName}.{moduleName}.{name}", sut.StreamName);
+    }
+
+    /// <summary>
+    ///     Ensures that the constructor rejects application names that contain whitespace, diacritics or
+    ///     other illegal characters.
+    /// </summary>
+    /// <param name="badName">An invalid application name.</param>
+    [Theory]
+    [InlineData("APP NAME")]
+    [InlineData("APP\tNAME")]
+    [InlineData("ÁPP")]
+    [InlineData("APP_NAME")]
+    public void ConstructorInternalWhitespaceOrIllegalCharsThrows(
+        string badName
+    )
+    {
+        ArgumentException ex =
+            Assert.Throws<ArgumentException>(() => new StreamNameAttribute(badName, "MODULE", "STREAM"));
+        Assert.Equal("appName", ex.ParamName);
+    }
+}

--- a/src/framework/EventSourcing.Abstractions/Attributes/StreamNameAttribute.cs
+++ b/src/framework/EventSourcing.Abstractions/Attributes/StreamNameAttribute.cs
@@ -1,0 +1,77 @@
+using System.Text.RegularExpressions;
+
+
+namespace Mississippi.EventSourcing.Abstractions.Attributes;
+
+/// <summary>
+///     Attribute used to define the name of a stream in the event sourcing system.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed partial class StreamNameAttribute : Attribute
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="StreamNameAttribute" /> class.
+    /// </summary>
+    /// <param name="appName">
+    ///     The application name component of the stream name. Must contain only uppercase alphanumeric
+    ///     characters.
+    /// </param>
+    /// <param name="moduleName">
+    ///     The module name component of the stream name. Must contain only uppercase alphanumeric
+    ///     characters.
+    /// </param>
+    /// <param name="name">The specific name component of the stream. Must contain only uppercase alphanumeric characters.</param>
+    public StreamNameAttribute(
+        string appName,
+        string moduleName,
+        string name
+    )
+    {
+        ValidateParameter(appName, nameof(appName));
+        ValidateParameter(moduleName, nameof(moduleName));
+        ValidateParameter(name, nameof(name));
+        AppName = appName;
+        ModuleName = moduleName;
+        Name = name;
+    }
+
+    /// <summary>
+    ///     Gets the application name component of the stream name.
+    /// </summary>
+    public string AppName { get; }
+
+    /// <summary>
+    ///     Gets the module name component of the stream name.
+    /// </summary>
+    public string ModuleName { get; }
+
+    /// <summary>
+    ///     Gets the specific name component of the stream.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    ///     Gets the fully qualified stream name in the format {AppName}.{ModuleName}.{Name}.
+    /// </summary>
+    public string StreamName => $"{AppName}.{ModuleName}.{Name}";
+
+    private static void ValidateParameter(
+        string value,
+        string paramName
+    )
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace", paramName);
+        }
+
+        Regex validationRegex = MyValidationRegex();
+        if (!validationRegex.IsMatch(value))
+        {
+            throw new ArgumentException("Value must contain only uppercase alphanumeric characters", paramName);
+        }
+    }
+
+    [GeneratedRegex("^[A-Z0-9]+$", RegexOptions.Compiled)]
+    private static partial Regex MyValidationRegex();
+}


### PR DESCRIPTION
This pull request introduces a new `StreamNameAttribute` class to define stream names in an event-sourcing system, along with comprehensive unit tests to validate its behavior. The changes ensure proper validation of input parameters and enforce strict naming conventions.

### New Feature: `StreamNameAttribute` Class

* Added the `StreamNameAttribute` class to encapsulate stream name components (`AppName`, `ModuleName`, `Name`) and enforce naming conventions. The class validates that all components contain only uppercase alphanumeric characters and provides a fully qualified stream name in the format `{AppName}.{ModuleName}.{Name}` (`src/framework/EventSourcing.Abstractions/Attributes/StreamNameAttribute.cs`).

### Unit Tests for `StreamNameAttribute`

* Introduced `StreamNameAttributeTests` to validate the behavior of the `StreamNameAttribute` class. Tests include:
  - Verifying property assignment for valid parameters.
  - Ensuring exceptions are thrown for null, empty, or improperly formatted parameters.
  - Testing edge cases like numeric-only or prefixed values (`src/framework/EventSourcing.Abstractions.Tests/Attributes/StreamNameAttributeTests.cs`).