### PR TITLE
Improve cross-platform build and cleanup scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,8 @@
 #!/usr/bin/env pwsh
+# Description: Cross-platform build script used by automation. Restores tools,
+# builds the solution, runs tests with coverage and optionally executes Stryker
+# mutation testing. Designed to run under PowerShell Core on Windows, Linux and
+# macOS.
 [CmdletBinding()]
 param (
     # Skip the build step entirely - useful when you just want to run tests on already built code
@@ -20,10 +24,10 @@ $ErrorActionPreference = "Stop"
 
 # Script variables
 $RepoRoot = $PSScriptRoot  # Root directory of the repository (where this script is located)
-$SolutionPath = Join-Path $RepoRoot "src\mississippi.sln"  # Path to the solution file
-$TestResultsDir = Join-Path $RepoRoot "test-results"  # Directory for test result outputs
-$CoverageOutputFile = Join-Path $RepoRoot "coverage.xml"  # Path for test coverage report
-$StrykerOutputDir = Join-Path $RepoRoot "src\StrykerOutput"  # Directory for mutation testing results
+$SolutionPath = Join-Path $RepoRoot (Join-Path 'src' 'mississippi.sln')  # Path to the solution file
+$TestResultsDir = Join-Path $RepoRoot 'test-results'  # Directory for test result outputs
+$CoverageOutputFile = Join-Path $RepoRoot 'coverage.xml'  # Path for test coverage report
+$StrykerOutputDir = Join-Path $RepoRoot (Join-Path 'src' 'StrykerOutput')  # Directory for mutation testing results
 
 # Ensure the test results directory exists
 if (-not (Test-Path $TestResultsDir)) {
@@ -65,7 +69,8 @@ function Get-SafePercentage {
 function Invoke-CommandLine {
     param (
         [string]$Command,
-        [string]$Arguments
+        [string]$Arguments,
+        [int[]]$AllowedExitCodes = @(0)
     )
 
     Write-Host "> $Command $Arguments" -ForegroundColor Yellow
@@ -93,7 +98,7 @@ function Invoke-CommandLine {
     if ($stderr) { Write-Host $stderr -ForegroundColor Red }
 
     # Throw an exception if the command failed
-    if ($process.ExitCode -ne 0) {
+    if ($AllowedExitCodes -notcontains $process.ExitCode) {
         throw "Command failed with exit code $($process.ExitCode)"
     }
 


### PR DESCRIPTION
## Summary
- make `build.ps1` and `cleanup.ps1` cross platform
- add descriptions for other AI agents
- update paths and dotnet tool usage
- allow ReSharper tools exit code 3
- fix newline endings

## Testing
- `pwsh ./build.ps1 -SkipStryker -SkipTests -SkipBuild`
- `pwsh ./cleanup.ps1 -SolutionPath /tmp/emptysln/emptysln.sln -DotSettingsPath /tmp/emptysln/nonexistent.DotSettings -Profile "Built-in: Full Cleanup"`

------
https://chatgpt.com/codex/tasks/task_e_68588e0afd108331987dc8224ba6f966