### PR TITLE
Enhance naming and Orleans guidelines with vertical slice folder

### DIFF
--- a/.cursor/rules/naming.mdc
+++ b/.cursor/rules/naming.mdc
@@ -30,6 +30,43 @@ This document establishes comprehensive naming conventions and XML documentation
 
 **Rule N-1:** Maximum five segments; PascalCase alphanumerics; no underscores; abbreviations only when industry-standard (`IO`, `DB`, `Html`).
 
+### 1.1 Vertical Slice Folder & Namespace Rules
+
+- **Feature-first folders** — The directory path MUST mirror the namespace segments exactly: `Company/Product/Feature[/SubFeature]`. Each folder represents a business feature or subfeature, not a technical layer.
+- **Prohibited horizontal folders** — You MUST NOT create technical silo folders at the root or within features, such as: `Models`, `Entities`, `Grains`, `Grain`, `Dtos`, `Dto`, `Services`, `Repositories`, `Repository`, `Interfaces`, `Enums`, `Extensions`, `Utils`, `Helpers`, `Common`. Use type names/suffixes to express roles; co-locate them with the feature.
+- **Types live with their feature** — You MUST place DTOs, handlers, options, validators, grains, etc. alongside the feature they serve. Example: `Mississippi/EventSourcing/Streams/EventStreamProcessor.cs` rather than `Mississippi/EventSourcing/Services/EventStreamProcessor.cs`.
+- **Allowed exceptions (narrow)** — A `ServiceRegistration.cs` per feature MAY be used (see service-registration guidelines). Optional `.Abstractions`/`.Infrastructure` segments MAY be used only when they are essential, stable product boundaries (see Step 4).
+
+Good
+
+```text
+Mississippi/
+  EventSourcing/
+    ServiceRegistration.cs
+    Streams/
+      EventStreamProcessor.cs
+      StreamSettings.cs
+      EventStreamProcessorLoggerExtensions.cs
+    Cosmos/
+      ServiceRegistration.cs
+      BrookStorageOptions.cs
+```
+
+Bad
+
+```text
+Mississippi/
+  EventSourcing/
+    Services/                 # ❌ horizontal layer
+      EventStreamProcessor.cs
+    Models/                   # ❌ horizontal layer
+      StreamSettings.cs
+    Grains/                   # ❌ horizontal layer
+      OrderGrain.cs
+    Dtos/                     # ❌ horizontal layer
+      OrderDto.cs
+```
+
 ## 2. Type-Naming Rules
 
 | ID  | Element                         | Rule                                                                                                                                                            |

--- a/.cursor/rules/orleans.mdc
+++ b/.cursor/rules/orleans.mdc
@@ -13,6 +13,12 @@ This document defines the Orleans development standards and best practices for t
 
 ## Core Principles
 
+### Folder Layout (Vertical Slices)
+
+- **You MUST NOT create a `Grains/` folder** or other horizontal technical silos (e.g., `Models`, `Dtos`, `Services`, `Repositories`). Organize grains and their collaborators under the feature they belong to, mirroring the namespace: `Company/Product/Feature[/SubFeature]`.
+- **You MUST place grains with their feature** (e.g., `Mississippi/EventSourcing/Orders/OrderGrain.cs`), not under a generic `Grains/` directory.
+- **Namespaces MUST mirror folders** and follow `Company.Product.Feature[.SubFeature]`. Type names SHOULD carry the `…Grain` suffix; folders MUST NOT.
+
 ### 1. NEVER Inherit from Grain ❌
 
 **CRITICAL RULE**: Never inherit from the `Grain` base class. Agents MUST always use the POCO (Plain Old CLR Object) grain pattern with `IGrainBase`.

--- a/.github/instructions/naming.instructions.md
+++ b/.github/instructions/naming.instructions.md
@@ -25,6 +25,43 @@ This document establishes comprehensive naming conventions and XML documentation
 
 **Rule N-1:** Maximum five segments; PascalCase alphanumerics; no underscores; abbreviations only when industry-standard (`IO`, `DB`, `Html`).
 
+### 1.1 Vertical Slice Folder & Namespace Rules
+
+- **Feature-first folders** — The directory path MUST mirror the namespace segments exactly: `Company/Product/Feature[/SubFeature]`. Each folder represents a business feature or subfeature, not a technical layer.
+- **Prohibited horizontal folders** — You MUST NOT create technical silo folders at the root or within features, such as: `Models`, `Entities`, `Grains`, `Grain`, `Dtos`, `Dto`, `Services`, `Repositories`, `Repository`, `Interfaces`, `Enums`, `Extensions`, `Utils`, `Helpers`, `Common`. Use type names/suffixes to express roles; co-locate them with the feature.
+- **Types live with their feature** — You MUST place DTOs, handlers, options, validators, grains, etc. alongside the feature they serve. Example: `Mississippi/EventSourcing/Streams/EventStreamProcessor.cs` rather than `Mississippi/EventSourcing/Services/EventStreamProcessor.cs`.
+- **Allowed exceptions (narrow)** — A `ServiceRegistration.cs` per feature MAY be used (see service-registration guidelines). Optional `.Abstractions`/`.Infrastructure` segments MAY be used only when they are essential, stable product boundaries (see Step 4).
+
+Good
+
+```text
+Mississippi/
+  EventSourcing/
+    ServiceRegistration.cs
+    Streams/
+      EventStreamProcessor.cs
+      StreamSettings.cs
+      EventStreamProcessorLoggerExtensions.cs
+    Cosmos/
+      ServiceRegistration.cs
+      BrookStorageOptions.cs
+```
+
+Bad
+
+```text
+Mississippi/
+  EventSourcing/
+    Services/                 # ❌ horizontal layer
+      EventStreamProcessor.cs
+    Models/                   # ❌ horizontal layer
+      StreamSettings.cs
+    Grains/                   # ❌ horizontal layer
+      OrderGrain.cs
+    Dtos/                     # ❌ horizontal layer
+      OrderDto.cs
+```
+
 ## 2. Type-Naming Rules
 
 | ID  | Element                         | Rule                                                                                                                                                            |

--- a/.github/instructions/orleans.instructions.md
+++ b/.github/instructions/orleans.instructions.md
@@ -8,6 +8,12 @@ This document defines the Orleans development standards and best practices for t
 
 ## Core Principles
 
+### Folder Layout (Vertical Slices)
+
+- **You MUST NOT create a `Grains/` folder** or other horizontal technical silos (e.g., `Models`, `Dtos`, `Services`, `Repositories`). Organize grains and their collaborators under the feature they belong to, mirroring the namespace: `Company/Product/Feature[/SubFeature]`.
+- **You MUST place grains with their feature** (e.g., `Mississippi/EventSourcing/Orders/OrderGrain.cs`), not under a generic `Grains/` directory.
+- **Namespaces MUST mirror folders** and follow `Company.Product.Feature[.SubFeature]`. Type names SHOULD carry the `…Grain` suffix; folders MUST NOT.
+
 ### 1. NEVER Inherit from Grain ❌
 
 **CRITICAL RULE**: Never inherit from the `Grain` base class. Agents MUST always use the POCO (Plain Old CLR Object) grain pattern with `IGrainBase`.


### PR DESCRIPTION
This pull request introduces a new section to both the naming and Orleans standards documentation, establishing clear folder and namespace conventions based on vertical slices. The main goal is to enforce feature-first organization and prohibit technical-layer (horizontal) folders, ensuring that code structure mirrors business features and namespaces.

**Vertical slice folder and namespace conventions:**

* Added explicit rules requiring that project directories and namespaces mirror business features, using the format `Company/Product/Feature[/SubFeature]`. Technical-layer folders like `Models`, `Services`, `Grains`, `Dtos`, etc., are now explicitly prohibited at both the root and feature levels. Types such as DTOs, handlers, and grains must be co-located with their respective features. [[1]](diffhunk://#diff-eabb9c7155bf1f19048e393454622789cbfb64ecd8e687ad927a7b80302f4be2R28-R64) [[2]](diffhunk://#diff-35ff46e9f6bb75da5557b5a66dcca783dafededa80669d14b9b84e85a9c05b71R33-R69)
* Provided clear examples of "good" (feature-first) and "bad" (horizontal silo) folder structures to illustrate the new requirements. [[1]](diffhunk://#diff-eabb9c7155bf1f19048e393454622789cbfb64ecd8e687ad927a7b80302f4be2R28-R64) [[2]](diffhunk://#diff-35ff46e9f6bb75da5557b5a66dcca783dafededa80669d14b9b84e85a9c05b71R33-R69)
* In the Orleans standards, added matching rules to forbid `Grains/` and similar horizontal folders, requiring grains and their collaborators to be organized under their feature and for namespaces to mirror this structure. [[1]](diffhunk://#diff-a4e9a377d39f4eb71b908768d940cfef0e6d3c54f2b4475d28231cbd78149d95R11-R16) [[2]](diffhunk://#diff-e883dac43fa63c27804e4eaccc04c9a2331ff913bfaa1a31a0b958c974c5f930R16-R21)

These updates are designed to promote maintainability, clarity, and alignment between code organization and business domains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds vertical-slice folder/namespace conventions and bans horizontal folders (incl. `Grains/`), with good/bad examples across naming and Orleans docs.
> 
> - **Naming guidelines (`.cursor/rules/naming.mdc`, `.github/instructions/naming.instructions.md`)**:
>   - Add vertical-slice folder/namespace rules requiring `Company/Product/Feature[/SubFeature]` structure mirroring namespaces.
>   - Explicitly prohibit horizontal technical folders (e.g., `Models`, `Services`, `Grains`, `Dtos`, etc.).
>   - Require co-locating types (DTOs, handlers, validators, grains) with their feature.
>   - Include "Good" and "Bad" folder structure examples.
> - **Orleans guidelines (`.cursor/rules/orleans.mdc`, `.github/instructions/orleans.instructions.md`)**:
>   - Add matching vertical-slice rules; forbid `Grains/` and other horizontal silos.
>   - Require namespaces to mirror folders; recommend `…Grain` suffix for types (not folders).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1b1a8d711f317f225c1ec25a8a88a6093d031e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->