### PR TITLE
Refactor build steps in copilot setup to explicitly build Mississippi…

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -90,7 +90,12 @@ jobs:
           dotnet tool run dotnet-gitversion /version
         continue-on-error: true
 
-      - name: Run build, tests and mutation testing (skip cleanup)
-        shell: pwsh
+      - name: Build Mississippi solution
         run: |
-          ./go.ps1 -Configuration Release -SkipCleanup
+          set -euo pipefail
+          dotnet build mississippi.slnx --configuration Release --no-restore
+
+      - name: Build Samples solution
+        run: |
+          set -euo pipefail
+          dotnet build samples.slnx --configuration Release --no-restore


### PR DESCRIPTION
This pull request updates the build steps in the GitHub Actions workflow to improve clarity and modularity. Instead of running a combined script for building, testing, and mutation testing, the workflow now separates the build process for the `mississippi` and `samples` solutions.

**Workflow improvements:**

* The single step for running build, tests, and mutation testing using `./go.ps1` has been replaced by two explicit build steps: one for `mississippi.slnx` and one for `samples.slnx`, both using `dotnet build` with the `Release` configuration and `--no-restore` flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the combined build/test script with two explicit `dotnet build` steps for `mississippi.slnx` and `samples.slnx` in the Copilot setup workflow.
> 
> - **CI Workflow (`.github/workflows/copilot-setup-steps.yml`)**:
>   - Replace the single script step that ran build/tests/mutation (`./go.ps1`) with explicit build steps.
>     - Add `Build Mississippi solution`: `dotnet build mississippi.slnx --configuration Release --no-restore`.
>     - Add `Build Samples solution`: `dotnet build samples.slnx --configuration Release --no-restore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfd2d0f24a909332b29658ae15df0caf717c7aa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->