### PR TITLE
Fixed a build error.

### DIFF
--- a/tests/EventSourcing.Serialization.Tests/packages.lock.json
+++ b/tests/EventSourcing.Serialization.Tests/packages.lock.json
@@ -237,14 +237,14 @@
           "xunit.abstractions": "2.0.3"
         }
       },
-      "Mississippi.EventSourcing.Serialization.Abstractions": {
-        "type": "Project"
-      },
-      "Mississippi.EventSourcing.Serialization.Json": {
+      "Mississippi.EventSourcing.Serialization": {
         "type": "Project",
         "dependencies": {
           "Mississippi.EventSourcing.Serialization.Abstractions": "[1.0.0, )"
         }
+      },
+      "Mississippi.EventSourcing.Serialization.Abstractions": {
+        "type": "Project"
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",


### PR DESCRIPTION
This pull request makes a small update to the project dependencies in the `tests/EventSourcing.Serialization.Tests/packages.lock.json` file, consolidating the serialization package references.

* Replaced the `Mississippi.EventSourcing.Serialization.Json` project reference with `Mississippi.EventSourcing.Serialization`, which now includes a dependency on `Mississippi.EventSourcing.Serialization.Abstractions`.….Serialization