### PR TITLE
Add reducer infrastructure and service registration for event sourcing

### DIFF
--- a/src/EventSourcing.Reducers.Abstractions/IReducer.cs
+++ b/src/EventSourcing.Reducers.Abstractions/IReducer.cs
@@ -1,0 +1,26 @@
+namespace Mississippi.EventSourcing.Reducers.Abstractions;
+
+/// <summary>
+///     Represents a component that updates a model in response to a single event.
+/// </summary>
+/// <typeparam name="TModel">The type of model being updated.</typeparam>
+public interface IReducer<TModel>
+    where TModel : class
+{
+    /// <summary>
+    ///     Applies the supplied event to the provided model instance.
+    /// </summary>
+    /// <param name="input">The immutable model snapshot prior to handling the event.</param>
+    /// <param name="eventData">The event being handled.</param>
+    /// <returns>The updated model.</returns>
+    /// <remarks>
+    ///     Implementations MUST treat <paramref name="input" /> as immutable. If a reducer needs to change
+    ///     state it MUST return a new <typeparamref name="TModel" /> instance that represents the updated
+    ///     model rather than mutating the provided reference. Immutable enforcement relies on value equality,
+    ///     so mutable reference types SHOULD override equality and hash-code semantics to enable guard rails.
+    /// </remarks>
+    TModel Reduce(
+        TModel input,
+        object eventData
+    );
+}

--- a/src/EventSourcing.Reducers.Abstractions/IRootReducer.cs
+++ b/src/EventSourcing.Reducers.Abstractions/IRootReducer.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Mississippi.EventSourcing.Reducers.Abstractions;
+
+/// <summary>
+///     Provides methods for applying ordered event streams to a model instance.
+/// </summary>
+/// <typeparam name="TModel">The type of model produced by the reducers.</typeparam>
+public interface IRootReducer<TModel>
+    where TModel : class
+{
+    /// <summary>
+    ///     Applies the provided events to the model using synchronous enumeration.
+    /// </summary>
+    /// <param name="input">The immutable model snapshot that serves as the starting point.</param>
+    /// <param name="events">The ordered event stream to replay.</param>
+    /// <returns>The new model snapshot after all events have been applied.</returns>
+    TModel Reduce(
+        TModel input,
+        IEnumerable<object> events
+    );
+
+    /// <summary>
+    ///     Applies the provided events to the model using asynchronous enumeration.
+    /// </summary>
+    /// <param name="input">The immutable model snapshot that serves as the starting point.</param>
+    /// <param name="events">The ordered asynchronous event stream to replay.</param>
+    /// <param name="cancellationToken">The token that signals when event replay should stop.</param>
+    /// <returns>A task-like value that completes with the new model snapshot.</returns>
+    ValueTask<TModel> ReduceAsync(
+        TModel input,
+        IAsyncEnumerable<object> events,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/EventSourcing.Reducers.Abstractions/ReducerBase.cs
+++ b/src/EventSourcing.Reducers.Abstractions/ReducerBase.cs
@@ -1,0 +1,39 @@
+namespace Mississippi.EventSourcing.Reducers.Abstractions;
+
+/// <summary>
+///     Provides a template for reducers that only handle a specific event type.
+/// </summary>
+/// <typeparam name="TModel">The model type operated on by the reducer.</typeparam>
+/// <typeparam name="TEvent">The event type handled by the reducer.</typeparam>
+public abstract class ReducerBase<TModel, TEvent> : IReducer<TModel>
+    where TModel : class
+{
+    /// <summary>
+    ///     Reduces the model in response to a strongly typed event.
+    /// </summary>
+    /// <param name="input">The model before the event is applied.</param>
+    /// <param name="eventData">The strongly typed event.</param>
+    /// <returns>The updated model.</returns>
+    /// <remarks>
+    ///     Implementations MUST treat <paramref name="input" /> as immutable and return a new model instance
+    ///     whenever state changes are required.
+    /// </remarks>
+    public abstract TModel Reduce(
+        TModel input,
+        TEvent eventData
+    );
+
+    /// <inheritdoc />
+    public TModel Reduce(
+        TModel input,
+        object eventData
+    )
+    {
+        if (eventData is TEvent typedEvent)
+        {
+            return Reduce(input, typedEvent);
+        }
+
+        return input;
+    }
+}

--- a/src/EventSourcing.Reducers/EventSourcing.Reducers.csproj
+++ b/src/EventSourcing.Reducers/EventSourcing.Reducers.csproj
@@ -2,4 +2,7 @@
   <ItemGroup>
     <ProjectReference Include="..\EventSourcing.Reducers.Abstractions\EventSourcing.Reducers.Abstractions.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
 </Project>

--- a/src/EventSourcing.Reducers/RootReducer.cs
+++ b/src/EventSourcing.Reducers/RootReducer.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Mississippi.EventSourcing.Reducers.Abstractions;
+
+
+namespace Mississippi.EventSourcing.Reducers;
+
+/// <summary>
+///     Default <see cref="IRootReducer{TModel}" /> implementation that sequentially applies reducers to events.
+/// </summary>
+/// <typeparam name="TModel">The model type produced by the reducers.</typeparam>
+public class RootReducer<TModel> : IRootReducer<TModel>
+    where TModel : class
+{
+    private static readonly EqualityComparer<TModel> ModelComparer = EqualityComparer<TModel>.Default;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="RootReducer{TModel}" /> class.
+    /// </summary>
+    /// <param name="reducers">The reducers to apply for each event.</param>
+    public RootReducer(
+        IEnumerable<IReducer<TModel>> reducers
+    )
+    {
+        ArgumentNullException.ThrowIfNull(reducers);
+        Reducers = reducers as IReadOnlyList<IReducer<TModel>> ?? reducers.ToArray();
+    }
+
+    private IReadOnlyList<IReducer<TModel>> Reducers { get; }
+
+    private static int? CaptureReferenceHash(
+        TModel model
+    )
+    {
+        if (model is null)
+        {
+            return null;
+        }
+
+        return ModelComparer.GetHashCode(model);
+    }
+
+    private static void EnsureImmutableTransition(
+        TModel previous,
+        TModel current,
+        int? hashBefore
+    )
+    {
+        if (!ReferenceEquals(previous, current))
+        {
+            return;
+        }
+
+        if (hashBefore is null || current is null)
+        {
+            return;
+        }
+
+        int hashAfter = ModelComparer.GetHashCode(current);
+        if (hashBefore == hashAfter)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Reducers must return a new model instance when mutating state. Use immutable updates or records.");
+    }
+
+    /// <inheritdoc />
+    public TModel Reduce(
+        TModel input,
+        IEnumerable<object> events
+    )
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        foreach (object eventData in events)
+        {
+            input = ApplyReducers(input, eventData);
+        }
+
+        return input;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<TModel> ReduceAsync(
+        TModel input,
+        IAsyncEnumerable<object> events,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        await foreach (object eventData in events.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            input = ApplyReducers(input, eventData);
+        }
+
+        return input;
+    }
+
+    private TModel ApplyReducers(
+        TModel input,
+        object eventData
+    )
+    {
+        foreach (IReducer<TModel> reducer in Reducers)
+        {
+            TModel previous = input;
+            int? stateHash = CaptureReferenceHash(previous);
+            TModel updated = reducer.Reduce(previous, eventData);
+            EnsureImmutableTransition(previous, updated, stateHash);
+            input = updated;
+        }
+
+        return input;
+    }
+}

--- a/src/EventSourcing.Reducers/ServiceRegistration.cs
+++ b/src/EventSourcing.Reducers/ServiceRegistration.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using Mississippi.EventSourcing.Reducers.Abstractions;
+
+
+namespace Mississippi.EventSourcing.Reducers;
+
+/// <summary>
+///     Provides helper methods for registering reducer components with the dependency injection container.
+/// </summary>
+public static class ServiceRegistration
+{
+    /// <summary>
+    ///     Registers the default reducer infrastructure for the EventSourcing reducers feature.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddEventSourcingReducers(
+        this IServiceCollection services
+    )
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        return services.AddEventSourcingReducersCore();
+    }
+
+    /// <summary>
+    ///     Registers a reducer type for its implemented <see cref="IReducer{TModel}" /> interface.
+    /// </summary>
+    /// <typeparam name="TReducer">The reducer implementation type.</typeparam>
+    /// <typeparam name="TModel">The model type handled by the reducer.</typeparam>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddReducer<TReducer, TModel>(
+        this IServiceCollection services
+    )
+        where TModel : class
+        where TReducer : class, IReducer<TModel>
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        return services.AddSingleton<IReducer<TModel>, TReducer>();
+    }
+
+    /// <summary>
+    ///     Registers a reducer for every <see cref="IReducer{TModel}" /> interface implemented by the reducer type.
+    /// </summary>
+    /// <typeparam name="TReducer">The reducer implementation type.</typeparam>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the reducer type does not implement
+    ///     <see cref="IReducer{TModel}" />.
+    /// </exception>
+    public static IServiceCollection AddReducer<TReducer>(
+        this IServiceCollection services
+    )
+        where TReducer : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        Type reducerType = typeof(TReducer);
+        bool registered = false;
+        foreach (Type reducerInterface in reducerType.GetInterfaces().Where(IsReducerInterface))
+        {
+            services.AddSingleton(reducerInterface, reducerType);
+            registered = true;
+        }
+
+        if (!registered)
+        {
+            throw new InvalidOperationException(
+                $"Type '{reducerType.FullName}' does not implement '{typeof(IReducer<>).Name}'.");
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    ///     Registers the default <see cref="IRootReducer{TModel}" /> implementation as an open generic so any model type is
+    ///     resolved.
+    /// </summary>
+    /// <typeparam name="TModel">The model type produced by the reducers.</typeparam>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddRootReducer<TModel>(
+        this IServiceCollection services
+    )
+        where TModel : class
+    {
+        // Maintain the legacy API while delegating to the feature-level registration method.
+        services.AddEventSourcingReducers();
+        services.TryAddSingleton<IRootReducer<TModel>, RootReducer<TModel>>();
+        return services;
+    }
+
+    private static IServiceCollection AddEventSourcingReducersCore(
+        this IServiceCollection services
+    )
+    {
+        services.TryAddSingleton(typeof(IRootReducer<>), typeof(RootReducer<>));
+        return services;
+    }
+
+    private static bool IsReducerInterface(
+        Type interfaceType
+    ) =>
+        interfaceType.IsGenericType && (interfaceType.GetGenericTypeDefinition() == typeof(IReducer<>));
+}

--- a/src/EventSourcing.Reducers/packages.lock.json
+++ b/src/EventSourcing.Reducers/packages.lock.json
@@ -14,6 +14,12 @@
         "resolved": "9.0.0",
         "contentHash": "JajbvkrBgtdRghavIjcJuNHMOja4lqBmEezbhZyqWPYh2cpLhT5mPpfC7NQVDO4IehWQum9t/nwF4v+qQGtYWg=="
       },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.0.11, )",
+        "resolved": "9.0.11",
+        "contentHash": "+ZxxZzcVU+IEzq12GItUzf/V3mEc5nSLiXijwvDc4zyhbjvSZZ043giSZqGnhakrjwRWjkerIHPrRwm9okEIpw=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",

--- a/tests/EventSourcing.Reducers.Abstractions.Tests/ReducerBaseTests.cs
+++ b/tests/EventSourcing.Reducers.Abstractions.Tests/ReducerBaseTests.cs
@@ -1,0 +1,51 @@
+namespace Mississippi.EventSourcing.Reducers.Abstractions.Tests;
+
+/// <summary>
+///     Verifies the shared behavior provided by <see cref="ReducerBase{TModel, TEvent}" />.
+/// </summary>
+public sealed class ReducerBaseTests
+{
+    private sealed record NumberModel(int Value);
+
+    private sealed class TrackingReducer : ReducerBase<NumberModel, int>
+    {
+        public int InvocationCount { get; private set; }
+
+        public override NumberModel Reduce(
+            NumberModel input,
+            int eventData
+        )
+        {
+            InvocationCount++;
+            return input with
+            {
+                Value = input.Value + eventData,
+            };
+        }
+    }
+
+    /// <summary>
+    ///     Ensures the typed Reduce overload is invoked when the event type matches.
+    /// </summary>
+    [Fact]
+    public void ReduceInvokesTypedReducerWhenEventMatches()
+    {
+        TrackingReducer reducer = new();
+        NumberModel result = reducer.Reduce(new(1), 2);
+        Assert.Equal(new(3), result);
+        Assert.Equal(1, reducer.InvocationCount);
+    }
+
+    /// <summary>
+    ///     Ensures the model instance is unchanged when the event type differs.
+    /// </summary>
+    [Fact]
+    public void ReduceReturnsOriginalModelWhenEventDoesNotMatch()
+    {
+        TrackingReducer reducer = new();
+        NumberModel model = new(5);
+        NumberModel result = reducer.Reduce(model, "ignored");
+        Assert.Same(model, result);
+        Assert.Equal(0, reducer.InvocationCount);
+    }
+}

--- a/tests/EventSourcing.Reducers.Tests/EventSourcing.Reducers.Tests.csproj
+++ b/tests/EventSourcing.Reducers.Tests/EventSourcing.Reducers.Tests.csproj
@@ -2,4 +2,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\EventSourcing.Reducers\EventSourcing.Reducers.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
 </Project>

--- a/tests/EventSourcing.Reducers.Tests/RootReducerTests.cs
+++ b/tests/EventSourcing.Reducers.Tests/RootReducerTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Mississippi.EventSourcing.Reducers.Abstractions;
+
+
+namespace Mississippi.EventSourcing.Reducers.Tests;
+
+/// <summary>
+///     Validates the default root reducer behavior.
+/// </summary>
+public sealed class RootReducerTests
+{
+    private static async IAsyncEnumerable<object> CreateAsyncEventsAsync(
+        params int[] events
+    )
+    {
+        foreach (int value in events)
+        {
+            await Task.Yield();
+            yield return value;
+        }
+    }
+
+    private static NumberModel CreateModel(
+        int value
+    ) =>
+        new(value);
+
+    private sealed record CounterModel(int AppliedEvents, int Total);
+
+    private sealed record IncrementEvent(int Amount);
+
+    private sealed class MutableModel
+    {
+        public MutableModel(
+            int value
+        ) =>
+            Value = value;
+
+        public int Value { get; private set; }
+
+        public override bool Equals(
+            object? obj
+        ) =>
+            obj is MutableModel other && (Value == other.Value);
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public void Increment(
+            int amount
+        )
+        {
+            Value += amount;
+        }
+    }
+
+    private sealed class MutatingReducer : IReducer<MutableModel>
+    {
+        public MutableModel Reduce(
+            MutableModel input,
+            object eventData
+        )
+        {
+            if (eventData is int amount)
+            {
+                input.Increment(amount);
+            }
+
+            return input;
+        }
+    }
+
+    private sealed class NoOpReducer : IReducer<MutableModel>
+    {
+        public MutableModel Reduce(
+            MutableModel input,
+            object eventData
+        ) =>
+            input;
+    }
+
+    private sealed record NumberModel(int Value);
+
+    private sealed class RecordCounterReducer : IReducer<CounterModel>
+    {
+        public CounterModel Reduce(
+            CounterModel input,
+            object eventData
+        )
+        {
+            if (eventData is not IncrementEvent incrementEvent)
+            {
+                return input;
+            }
+
+            // Records use with-expressions to produce an updated immutable copy.
+            return input with
+            {
+                AppliedEvents = input.AppliedEvents + 1,
+                Total = input.Total + incrementEvent.Amount,
+            };
+        }
+    }
+
+    private sealed class TestReducer : IReducer<NumberModel>
+    {
+        private readonly Func<int, int, int> reduce;
+
+        public TestReducer(
+            Func<int, int, int> reduce
+        ) =>
+            this.reduce = reduce;
+
+        public NumberModel Reduce(
+            NumberModel input,
+            object eventData
+        )
+        {
+            if (eventData is not int value)
+            {
+                return input;
+            }
+
+            return input with
+            {
+                Value = reduce(input.Value, value),
+            };
+        }
+    }
+
+    /// <summary>
+    ///     Ensures reducers may return the same reference when no changes are required.
+    /// </summary>
+    [Fact]
+    public void ReduceAllowsReturningSameInstanceWhenStateUnchanged()
+    {
+        IReducer<MutableModel>[] reducers = new IReducer<MutableModel>[] { new NoOpReducer() };
+        RootReducer<MutableModel> rootReducer = new(reducers);
+        MutableModel startingModel = new(5);
+        MutableModel result = rootReducer.Reduce(startingModel, Array.Empty<object>());
+        Assert.Same(startingModel, result);
+    }
+
+    /// <summary>
+    ///     Ensures the synchronous reducer applies nested reducers sequentially.
+    /// </summary>
+    [Fact]
+    public void ReduceAppliesReducersSequentially()
+    {
+        IReducer<NumberModel>[] reducers = new IReducer<NumberModel>[]
+        {
+            new TestReducer((
+                current,
+                value
+            ) => current + value),
+            new TestReducer((
+                current,
+                value
+            ) => current * value),
+        };
+        RootReducer<NumberModel> rootReducer = new(reducers);
+        NumberModel result = rootReducer.Reduce(CreateModel(1), new object[] { 2, 3 });
+        Assert.Equal(CreateModel(27), result);
+    }
+
+    /// <summary>
+    ///     Ensures the asynchronous reducer applies nested reducers sequentially.
+    /// </summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous assertion.</returns>
+    [Fact]
+    public async Task ReduceAsyncAppliesReducersSequentially()
+    {
+        IReducer<NumberModel>[] reducers = new IReducer<NumberModel>[]
+        {
+            new TestReducer((
+                current,
+                value
+            ) => current + value),
+            new TestReducer((
+                current,
+                value
+            ) => current - value),
+        };
+        RootReducer<NumberModel> rootReducer = new(reducers);
+        IAsyncEnumerable<object> events = CreateAsyncEventsAsync(4, 1);
+        NumberModel result = await rootReducer.ReduceAsync(CreateModel(10), events, CancellationToken.None);
+        Assert.Equal(CreateModel(10), result);
+    }
+
+    /// <summary>
+    ///     Ensures cancellation tokens are honored during asynchronous reduction.
+    /// </summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous assertion.</returns>
+    [Fact]
+    public async Task ReduceAsyncThrowsWhenCancellationRequested()
+    {
+        IReducer<NumberModel>[] reducers = new IReducer<NumberModel>[]
+        {
+            new TestReducer((
+                current,
+                value
+            ) => current + value),
+        };
+        RootReducer<NumberModel> rootReducer = new(reducers);
+        using CancellationTokenSource cancellationTokenSource = new();
+        await cancellationTokenSource.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await rootReducer.ReduceAsync(CreateModel(0), CreateAsyncEventsAsync(1), cancellationTokenSource.Token);
+        });
+    }
+
+    /// <summary>
+    ///     Ensures asynchronous reductions also enforce immutability.
+    /// </summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous assertion.</returns>
+    [Fact]
+    public async Task ReduceAsyncThrowsWhenReducerMutatesModelInstance()
+    {
+        IReducer<MutableModel>[] reducers = new IReducer<MutableModel>[] { new MutatingReducer() };
+        RootReducer<MutableModel> rootReducer = new(reducers);
+        MutableModel startingModel = new(0);
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await rootReducer.ReduceAsync(startingModel, CreateAsyncEventsAsync(1));
+        });
+    }
+
+    /// <summary>
+    ///     Demonstrates the recommended record + with-expression pattern for immutable reducers.
+    /// </summary>
+    [Fact]
+    public void ReduceSupportsRecordStatesUsingWithExpressions()
+    {
+        CounterModel startingModel = new(0, 0);
+        object[] events = new object[] { new IncrementEvent(5), new IncrementEvent(2) };
+        RootReducer<CounterModel> rootReducer = new(new IReducer<CounterModel>[] { new RecordCounterReducer() });
+        CounterModel result = rootReducer.Reduce(startingModel, events);
+        Assert.Equal(new(2, 7), result);
+        Assert.NotSame(startingModel, result);
+    }
+
+    /// <summary>
+    ///     Ensures reducers cannot mutate the existing model instance when producing changes.
+    /// </summary>
+    [Fact]
+    public void ReduceThrowsWhenReducerMutatesModelInstance()
+    {
+        IReducer<MutableModel>[] reducers = new IReducer<MutableModel>[] { new MutatingReducer() };
+        RootReducer<MutableModel> rootReducer = new(reducers);
+        MutableModel startingModel = new(0);
+        Assert.Throws<InvalidOperationException>(() => rootReducer.Reduce(startingModel, new object[] { 1 }));
+    }
+}

--- a/tests/EventSourcing.Reducers.Tests/ServiceRegistrationTests.cs
+++ b/tests/EventSourcing.Reducers.Tests/ServiceRegistrationTests.cs
@@ -1,0 +1,142 @@
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Mississippi.EventSourcing.Reducers.Abstractions;
+
+
+namespace Mississippi.EventSourcing.Reducers.Tests;
+
+/// <summary>
+///     Exercises the public service registration surface for reducers.
+/// </summary>
+public sealed class ServiceRegistrationTests
+{
+    private sealed class MultiReducer
+        : IReducer<NumberModel>,
+          IReducer<TextModel>
+    {
+        NumberModel IReducer<NumberModel>.Reduce(
+            NumberModel input,
+            object eventData
+        )
+        {
+            if (eventData is not int delta)
+            {
+                return input;
+            }
+
+            return input with
+            {
+                Value = input.Value + delta,
+            };
+        }
+
+        TextModel IReducer<TextModel>.Reduce(
+            TextModel input,
+            object eventData
+        )
+        {
+            if (eventData is not string text)
+            {
+                return input;
+            }
+
+            return input with
+            {
+                Value = input.Value + text,
+            };
+        }
+    }
+
+    private sealed class NonReducer
+    {
+        public int Sentinel { get; } = 42;
+    }
+
+    private sealed record NumberModel(int Value);
+
+    private sealed class TestReducer : IReducer<NumberModel>
+    {
+        public NumberModel Reduce(
+            NumberModel input,
+            object eventData
+        )
+        {
+            if (eventData is not int delta)
+            {
+                return input;
+            }
+
+            return input with
+            {
+                Value = input.Value + delta,
+            };
+        }
+    }
+
+    private sealed record TextModel(string Value);
+
+    /// <summary>
+    ///     Ensures the feature-level registration wires the default root reducer.
+    /// </summary>
+    [Fact]
+    public void AddEventSourcingReducersRegistersRootReducer()
+    {
+        ServiceCollection services = new();
+        services.AddEventSourcingReducers();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IRootReducer<NumberModel> reducer = provider.GetRequiredService<IRootReducer<NumberModel>>();
+        Assert.IsType<RootReducer<NumberModel>>(reducer);
+    }
+
+    /// <summary>
+    ///     Ensures reducers registered with explicit model types are resolved as singletons.
+    /// </summary>
+    [Fact]
+    public void AddReducerWithModelTypeRegistersReducer()
+    {
+        ServiceCollection services = new();
+        services.AddReducer<TestReducer, NumberModel>();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IReducer<NumberModel> reducer = provider.GetRequiredService<IReducer<NumberModel>>();
+        Assert.IsType<TestReducer>(reducer);
+    }
+
+    /// <summary>
+    ///     Ensures reducers registered via reflection bind to all supported model types.
+    /// </summary>
+    [Fact]
+    public void AddReducerWithoutModelTypeRegistersAllImplementedInterfaces()
+    {
+        ServiceCollection services = new();
+        services.AddReducer<MultiReducer>();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.IsType<MultiReducer>(provider.GetRequiredService<IReducer<NumberModel>>());
+        Assert.IsType<MultiReducer>(provider.GetRequiredService<IReducer<TextModel>>());
+    }
+
+    /// <summary>
+    ///     Ensures an informative exception is thrown when the type lacks reducer interfaces.
+    /// </summary>
+    [Fact]
+    public void AddReducerWithoutReducerInterfaceThrowsInvalidOperation()
+    {
+        ServiceCollection services = new();
+        Assert.Throws<InvalidOperationException>(() => services.AddReducer<NonReducer>());
+        Assert.Equal(42, new NonReducer().Sentinel);
+    }
+
+    /// <summary>
+    ///     Ensures the legacy registration delegates to the feature-level overload.
+    /// </summary>
+    [Fact]
+    public void AddRootReducerDelegatesToAddEventSourcingReducers()
+    {
+        ServiceCollection services = new();
+        services.AddRootReducer<NumberModel>();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IRootReducer<NumberModel> reducer = provider.GetRequiredService<IRootReducer<NumberModel>>();
+        Assert.IsType<RootReducer<NumberModel>>(reducer);
+    }
+}

--- a/tests/EventSourcing.Reducers.Tests/packages.lock.json
+++ b/tests/EventSourcing.Reducers.Tests/packages.lock.json
@@ -33,6 +33,15 @@
         "resolved": "9.0.0",
         "contentHash": "JajbvkrBgtdRghavIjcJuNHMOja4lqBmEezbhZyqWPYh2cpLhT5mPpfC7NQVDO4IehWQum9t/nwF4v+qQGtYWg=="
       },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[9.0.11, )",
+        "resolved": "9.0.11",
+        "contentHash": "UquyDzvz0EneIQrrU67GJkIgynS+VD7t+RDtNv6VgKMOFrLBjldn6hzlXppGGecFMvAkMTqn4T8RYvzw7j7fQA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.14.1, )",
@@ -240,11 +249,18 @@
       "Mississippi.EventSourcing.Reducers": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.11, )",
           "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )"
         }
       },
       "Mississippi.EventSourcing.Reducers.Abstractions": {
         "type": "Project"
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.11, )",
+        "resolved": "9.0.11",
+        "contentHash": "+ZxxZzcVU+IEzq12GItUzf/V3mEc5nSLiXijwvDc4zyhbjvSZZ043giSZqGnhakrjwRWjkerIHPrRwm9okEIpw=="
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",


### PR DESCRIPTION
This pull request introduces a new event-sourcing reducers infrastructure for .NET, focusing on immutability and extensibility. It adds core abstractions for reducers, a default root reducer implementation, dependency injection registration helpers, and comprehensive unit tests to enforce correct behavior and immutability guarantees.

**Core abstractions and implementation:**

* Added the `IReducer<TModel>` and `IRootReducer<TModel>` interfaces in `Mississippi.EventSourcing.Reducers.Abstractions` to define how models are updated in response to events, both individually and as ordered streams. [[1]](diffhunk://#diff-ad228bd55c854e86fc8cb8df34c953b7741c9aa876b195db166140f6bc0128a4R1-R26) [[2]](diffhunk://#diff-a87c154c5311af96e2d0484f6b98ff6c11d03c49a2f46b5c0b09c060da9c808aR1-R38)
* Implemented the `ReducerBase<TModel, TEvent>` abstract class to simplify writing reducers that handle specific event types, including logic to only apply updates for matching event types.
* Added the default `RootReducer<TModel>` class, which applies a sequence of reducers to a stream of events, enforcing immutability by requiring new model instances for state changes and throwing exceptions if reducers mutate the original instance.

**Dependency injection and package management:**

* Introduced the `ServiceRegistration` static class with extension methods for registering reducers and the root reducer with the dependency injection container, supporting both open generics and specific reducer types.
* Added a dependency on `Microsoft.Extensions.DependencyInjection.Abstractions` in `EventSourcing.Reducers.csproj` and updated the lock file to ensure DI support. [[1]](diffhunk://#diff-7fb3eea9c57fffebfc7bc25161ade00dc8e9997dfe217b970230e691b1dfad6dR5-R7) [[2]](diffhunk://#diff-5f7be9d005d26f127cbd8ca6e26493b1e28d95967df5f711b2a9aaee0477e733R17-R22)
* Updated the test project to reference `Microsoft.Extensions.DependencyInjection` for integration testing.

**Testing and validation:**

* Added comprehensive unit tests for `ReducerBase` and `RootReducer` to validate correct reducer invocation, sequential application of reducers, asynchronous event handling, cancellation support, and strict enforcement of immutability. [[1]](diffhunk://#diff-ea84a300f8998cde8972049f3dad2cb6207d43d884531353d73680ed5840bc52R1-R51) [[2]](diffhunk://#diff-911e5a9e945617961fbfaa578f8ca2d2ee70141f9039128d603cbb500d0cf226R1-R257)