### PR TITLE
Remove Mississippi and Samples solution steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -85,29 +85,9 @@ jobs:
           set -euo pipefail
           dotnet tool restore
 
-      - name: Restore Mississippi solution packages
-        run: |
-          set -euo pipefail
-          dotnet restore mississippi.slnx
-
-      - name: Restore Samples solution packages
-        run: |
-          set -euo pipefail
-          dotnet restore samples.slnx
-
       - name: Prime GitVersion tool cache
         if: steps.check-tools-manifest.outputs.manifest_exists == 'true'
         run: |
           set -euo pipefail
           dotnet tool run dotnet-gitversion /version
         continue-on-error: true
-
-      - name: Build Mississippi solution
-        run: |
-          set -euo pipefail
-          dotnet build mississippi.slnx --configuration Release --no-restore
-
-      - name: Build Samples solution
-        run: |
-          set -euo pipefail
-          dotnet build samples.slnx --configuration Release --no-restore


### PR DESCRIPTION
This pull request simplifies the `.github/workflows/copilot-setup-steps.yml` workflow by removing steps related to restoring and building the `mississippi.slnx` and `samples.slnx` solutions.

Workflow simplification:

* Removed steps for restoring NuGet packages for both `mississippi.slnx` and `samples.slnx` solutions, reducing setup complexity.
* Removed build steps for both `mississippi.slnx` and `samples.slnx`, streamlining the workflow to focus only on essential tasks.Removed steps for restoring and building Mississippi and Samples solutions.

Not needed for all changes, so using extra time not needed.