### PR TITLE
refactor: Replace concrete-to-concrete dependencies with abstractions

### DIFF
--- a/src/EventSourcing.Aggregates/EventSourcing.Aggregates.csproj
+++ b/src/EventSourcing.Aggregates/EventSourcing.Aggregates.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\EventSourcing.Aggregates.Abstractions\EventSourcing.Aggregates.Abstractions.csproj" />
-    <ProjectReference Include="..\EventSourcing.Brooks\EventSourcing.Brooks.csproj" />
-    <ProjectReference Include="..\EventSourcing.Reducers\EventSourcing.Reducers.csproj" />
+    <ProjectReference Include="..\EventSourcing.Brooks.Abstractions\EventSourcing.Brooks.Abstractions.csproj" />
+    <ProjectReference Include="..\EventSourcing.Reducers.Abstractions\EventSourcing.Reducers.Abstractions.csproj" />
     <ProjectReference Include="..\EventSourcing.Serialization.Abstractions\EventSourcing.Serialization.Abstractions.csproj" />
     <ProjectReference Include="..\EventSourcing.Snapshots.Abstractions\EventSourcing.Snapshots.Abstractions.csproj" />
   </ItemGroup>

--- a/src/EventSourcing.Snapshots/EventSourcing.Snapshots.csproj
+++ b/src/EventSourcing.Snapshots/EventSourcing.Snapshots.csproj
@@ -4,7 +4,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventSourcing.Aggregates.Abstractions\EventSourcing.Aggregates.Abstractions.csproj" />
-    <ProjectReference Include="..\EventSourcing.Brooks\EventSourcing.Brooks.csproj" />
+    <ProjectReference Include="..\EventSourcing.Brooks.Abstractions\EventSourcing.Brooks.Abstractions.csproj" />
     <ProjectReference Include="..\EventSourcing.Reducers.Abstractions\EventSourcing.Reducers.Abstractions.csproj" />
     <ProjectReference Include="..\EventSourcing.Serialization.Abstractions\EventSourcing.Serialization.Abstractions.csproj" />
     <ProjectReference Include="..\EventSourcing.Snapshots.Abstractions\EventSourcing.Snapshots.Abstractions.csproj" />

--- a/src/EventSourcing.UxProjections/EventSourcing.UxProjections.csproj
+++ b/src/EventSourcing.UxProjections/EventSourcing.UxProjections.csproj
@@ -3,7 +3,7 @@
 		<PackageReference Include="Microsoft.Orleans.Sdk" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\EventSourcing.Brooks\EventSourcing.Brooks.csproj" />
+		<ProjectReference Include="..\EventSourcing.Brooks.Abstractions\EventSourcing.Brooks.Abstractions.csproj" />
 		<ProjectReference Include="..\EventSourcing.Reducers.Abstractions\EventSourcing.Reducers.Abstractions.csproj" />
 		<ProjectReference Include="..\EventSourcing.Snapshots.Abstractions\EventSourcing.Snapshots.Abstractions.csproj" />
 		<ProjectReference Include="..\EventSourcing.UxProjections.Abstractions\EventSourcing.UxProjections.Abstractions.csproj" />

--- a/tests/Architecture.L0Tests/packages.lock.json
+++ b/tests/Architecture.L0Tests/packages.lock.json
@@ -1487,8 +1487,8 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.11, )",
           "Microsoft.Orleans.Sdk": "[9.2.1, )",
           "Mississippi.EventSourcing.Aggregates.Abstractions": "[1.0.0, )",
-          "Mississippi.EventSourcing.Brooks": "[1.0.0, )",
-          "Mississippi.EventSourcing.Reducers": "[1.0.0, )",
+          "Mississippi.EventSourcing.Brooks.Abstractions": "[1.0.0, )",
+          "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Serialization.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Snapshots.Abstractions": "[1.0.0, )"
         }
@@ -1571,7 +1571,7 @@
         "dependencies": {
           "Microsoft.Orleans.Sdk": "[9.2.1, )",
           "Mississippi.EventSourcing.Aggregates.Abstractions": "[1.0.0, )",
-          "Mississippi.EventSourcing.Brooks": "[1.0.0, )",
+          "Mississippi.EventSourcing.Brooks.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Serialization.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Snapshots.Abstractions": "[1.0.0, )"
@@ -1600,7 +1600,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Orleans.Sdk": "[9.2.1, )",
-          "Mississippi.EventSourcing.Brooks": "[1.0.0, )",
+          "Mississippi.EventSourcing.Brooks.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Snapshots.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.UxProjections.Abstractions": "[1.0.0, )"

--- a/tests/EventSourcing.Aggregates.L0Tests/EventSourcing.Aggregates.L0Tests.csproj
+++ b/tests/EventSourcing.Aggregates.L0Tests/EventSourcing.Aggregates.L0Tests.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\EventSourcing.Aggregates\EventSourcing.Aggregates.csproj" />
+    <ProjectReference Include="..\..\src\EventSourcing.Brooks\EventSourcing.Brooks.csproj" />
+    <ProjectReference Include="..\..\src\EventSourcing.Reducers\EventSourcing.Reducers.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/EventSourcing.Aggregates.L0Tests/packages.lock.json
+++ b/tests/EventSourcing.Aggregates.L0Tests/packages.lock.json
@@ -677,8 +677,8 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.11, )",
           "Microsoft.Orleans.Sdk": "[9.2.1, )",
           "Mississippi.EventSourcing.Aggregates.Abstractions": "[1.0.0, )",
-          "Mississippi.EventSourcing.Brooks": "[1.0.0, )",
-          "Mississippi.EventSourcing.Reducers": "[1.0.0, )",
+          "Mississippi.EventSourcing.Brooks.Abstractions": "[1.0.0, )",
+          "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Serialization.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Snapshots.Abstractions": "[1.0.0, )"
         }

--- a/tests/EventSourcing.Snapshots.L0Tests/EventSourcing.Snapshots.L0Tests.csproj
+++ b/tests/EventSourcing.Snapshots.L0Tests/EventSourcing.Snapshots.L0Tests.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EventSourcing.Brooks\EventSourcing.Brooks.csproj" />
+    <ProjectReference Include="..\..\src\EventSourcing.Reducers\EventSourcing.Reducers.csproj" />
     <ProjectReference Include="..\..\src\EventSourcing.Snapshots\EventSourcing.Snapshots.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/EventSourcing.Snapshots.L0Tests/packages.lock.json
+++ b/tests/EventSourcing.Snapshots.L0Tests/packages.lock.json
@@ -699,6 +699,14 @@
           "Mississippi.Common.Abstractions": "[1.0.0, )"
         }
       },
+      "Mississippi.EventSourcing.Reducers": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.11, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[9.0.1, )",
+          "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )"
+        }
+      },
       "Mississippi.EventSourcing.Reducers.Abstractions": {
         "type": "Project"
       },
@@ -715,7 +723,7 @@
         "dependencies": {
           "Microsoft.Orleans.Sdk": "[9.2.1, )",
           "Mississippi.EventSourcing.Aggregates.Abstractions": "[1.0.0, )",
-          "Mississippi.EventSourcing.Brooks": "[1.0.0, )",
+          "Mississippi.EventSourcing.Brooks.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Serialization.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Snapshots.Abstractions": "[1.0.0, )"

--- a/tests/EventSourcing.UxProjections.L0Tests/EventSourcing.UxProjections.L0Tests.csproj
+++ b/tests/EventSourcing.UxProjections.L0Tests/EventSourcing.UxProjections.L0Tests.csproj
@@ -5,6 +5,7 @@
         <PackageReference Include="System.Linq.Async"/>
     </ItemGroup>
     <ItemGroup>
+        <ProjectReference Include="..\..\src\EventSourcing.Brooks\EventSourcing.Brooks.csproj" />
         <ProjectReference Include="..\..\src\EventSourcing.UxProjections\EventSourcing.UxProjections.csproj" />
         <ProjectReference Include="..\Testing.Utilities\Testing.Utilities.csproj" />
     </ItemGroup>

--- a/tests/EventSourcing.UxProjections.L0Tests/packages.lock.json
+++ b/tests/EventSourcing.UxProjections.L0Tests/packages.lock.json
@@ -797,7 +797,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Orleans.Sdk": "[9.2.1, )",
-          "Mississippi.EventSourcing.Brooks": "[1.0.0, )",
+          "Mississippi.EventSourcing.Brooks.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Reducers.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.Snapshots.Abstractions": "[1.0.0, )",
           "Mississippi.EventSourcing.UxProjections.Abstractions": "[1.0.0, )"


### PR DESCRIPTION
Fix architectural violation where EventSourcing projects depended on concrete implementations instead of abstractions:

- EventSourcing.Aggregates: Brooks → Brooks.Abstractions, Reducers → Reducers.Abstractions
- EventSourcing.Snapshots: Brooks → Brooks.Abstractions
- EventSourcing.UxProjections: Brooks → Brooks.Abstractions

Test projects updated to reference concrete implementations for integration testing.

All architecture tests pass. Zero warnings. All 1,612 tests pass.