### PR TITLE
Add documentation structure guidelines and mobile-friendly mermaid rules +semver: skip

### DIFF
--- a/.github/instructions/documentation-authoring.instructions.md
+++ b/.github/instructions/documentation-authoring.instructions.md
@@ -22,6 +22,7 @@ Governing thought: Every documentation page exists to enable a decision or actio
 - Authors **MUST** link concepts, features, and commands to their descriptions on first mention. Why: Enables bottom-up navigation.
 - Code samples **MUST** be minimal but complete, placed in fenced blocks with language identifiers. Why: Working examples accelerate understanding.
 - Diagrams and flowcharts **SHOULD** be used for architecture, processes, and data relationships; all images **MUST** include alt text. Why: Accessibility and comprehension.
+- Mermaid diagrams **MUST** use `flowchart LR` (left-to-right) by default; `flowchart TB` (top-to-bottom) **MUST NOT** be used unless the diagram explicitly represents a vertical hierarchy. Why: Mobile screens display LR diagrams without horizontal scrolling.
 - Authors **MUST** update docs when features, performance characteristics, or components change; authors **MUST NOT** add "last updated" or timestamp fields because Git history is the source of truth. Why: Prevents drift and conflicting metadata.
 
 ## Scope and Audience

--- a/.github/instructions/documentation-page-focus.instructions.md
+++ b/.github/instructions/documentation-page-focus.instructions.md
@@ -1,0 +1,80 @@
+---
+applyTo: 'docs/**/*.md'
+---
+
+# Documentation Page Focus
+
+Governing thought: Every documentation page serves one audience with one purpose—mixing public API guidance with internal implementation details creates confusion.
+
+> Drift check: This file defines page focus rules for `docs/Docusaurus/`; update as documentation patterns evolve.
+
+## Rules (RFC 2119)
+
+- Each page **MUST** declare its focus in the Overview section as either **Public API / Developer Experience** or **Internal Implementation**. Why: Readers must know immediately whether the page helps them build on the framework or understand its internals.
+- **Public API / Developer Experience** pages **MUST** focus on contracts, usage patterns, configuration, and outcomes a developer building on Mississippi will encounter. They **MUST NOT** explain implementation internals beyond what is necessary to use the API correctly. Why: DX-focused readers need actionable guidance, not source-code walkthroughs.
+- **Internal Implementation** pages **MUST** focus on how the framework works under the hood, architectural decisions, performance characteristics, and extension points. They **SHOULD** assume the reader already understands the public API. Why: Implementation-focused readers need depth, not introductory usage examples.
+- Pages **MUST NOT** mix both concerns; if a topic requires both, authors **MUST** split into separate pages and cross-link them. Why: Mixed pages force readers to skip irrelevant sections and obscure the page's purpose.
+- The page's focus **SHOULD** be reflected in its location within the sidebar hierarchy (e.g., `internals/` vs feature folders). Why: Consistent placement aids discoverability.
+
+## Scope and Audience
+
+All contributors writing or updating documentation in `docs/Docusaurus/`.
+
+## At-a-Glance Quick-Start
+
+- Decide before writing: Is this page for someone **using** the feature or someone **understanding** how it works internally?
+- State the focus explicitly in the Overview section.
+- Keep content aligned with the declared focus; split if needed.
+- Place pages in the appropriate sidebar section.
+
+## Focus Types
+
+### Public API / Developer Experience
+
+These pages answer: *How do I use this?*
+
+| Include | Exclude |
+|---------|---------|
+| Public types, interfaces, and contracts | Private/internal types |
+| Configuration options and defaults | Implementation algorithms |
+| Code examples showing typical usage | Source-code line-by-line walkthroughs |
+| Error messages and troubleshooting | Performance internals (unless user-actionable) |
+| Migration guidance and breaking changes | Historical design decisions |
+
+**Indicators**: The reader is building an application on Mississippi.
+
+### Internal Implementation
+
+These pages answer: *How does this work?*
+
+| Include | Exclude |
+|---------|---------|
+| Architectural diagrams and data flow | Step-by-step usage tutorials |
+| Algorithm explanations and trade-offs | Configuration quickstarts |
+| Performance characteristics and benchmarks | Basic "hello world" examples |
+| Extension points and customization hooks | Public API reference tables |
+| Design rationale and alternatives considered | Getting started guidance |
+
+**Indicators**: The reader is contributing to Mississippi, debugging deep issues, or evaluating the framework's design.
+
+## Example Overview Statements
+
+### Public API Focus
+
+> This page documents the `IBrookGrainFactory` interface and shows how to read and write events to brooks in your application.
+
+### Internal Implementation Focus
+
+> This page explains how the saga orchestration effect drives step execution and compensation internally. For usage guidance, see [Sagas](../event-sourcing/sagas/sagas.md).
+
+## Core Principles
+
+- **Single Audience**: One page, one reader profile.
+- **Clear Purpose**: The overview tells the reader if they're in the right place.
+- **Navigable Split**: Cross-links connect related pages with different focuses.
+
+## References
+
+- Feature documentation structure: `.github/instructions/feature-documentation-structure.instructions.md`
+- Documentation authoring: `.github/instructions/documentation-authoring.instructions.md`
+- Documentation guide: `docs/Docusaurus/docs/contributing/documentation-guide.md`

--- a/.github/instructions/feature-documentation-structure.instructions.md
+++ b/.github/instructions/feature-documentation-structure.instructions.md
@@ -1,0 +1,188 @@
+---
+applyTo: 'docs/**/*.md'
+---
+
+# Feature Documentation Structure
+
+Governing thought: Every Mississippi feature follows a predictable documentation structure with strict content segregation—readers always know where to find what they need.
+
+> Drift check: This file defines the standard feature folder structure for `docs/Docusaurus/`; update as documentation patterns evolve.
+
+## Rules (RFC 2119)
+
+### Structure Rules
+
+- Each feature **MUST** have an entry page named `{feature}.md` that serves as both introduction and getting started. Why: Single entry point per Docusaurus best practices.
+- The entry page **MUST** be referenced in `_category_.json` via the `link.id` property. Why: Makes the folder clickable in the sidebar.
+- Optional pages **MUST** only be created when there is substantial content for that page type. Why: Avoids empty or stub pages.
+- Features **MUST NOT** have more than two levels of nesting (area → feature → page). Why: Deep hierarchies obscure navigation.
+
+### Content Segregation Rules (Non-Negotiable)
+
+- Content **MUST** appear only on the page type designated for it; mixing content across page types is prohibited. Why: Readers must find all related content in one place.
+- Testing guidance (mocks, test utilities, test setup) **MUST** appear only on `testing.md`. Why: Developers looking for testing help check one page.
+- Configuration options **MUST** appear only on `configuration.md` (or entry page if no dedicated config page exists). Why: All settings in one place.
+- API reference tables **MUST** appear only on `public-apis.md` (or entry page if no dedicated API page exists). Why: Reference material stays together.
+- Internal implementation details **MUST** appear only on `internals.md`. Why: Separates DX from contributor content.
+- Best practices and anti-patterns **MUST** appear only on `best-practices.md`. Why: Pattern guidance stays consolidated.
+- Migration guides **MUST** appear only in the `migration/` subfolder. Why: Version-specific content is isolated.
+- Sample project links and extended examples **MUST** appear only on `samples.md` (brief inline examples in other pages are permitted). Why: Comprehensive examples are discoverable.
+
+### Naming Rules
+
+- Area folders **MUST** use kebab-case matching the product area (e.g., `event-sourcing`, `client-state-management`). Why: Consistent URLs.
+- Feature folders **MUST** use kebab-case matching the feature name (e.g., `brooks`, `aggregates`, `sagas`). Why: Matches sidebar labels.
+- Page files **MUST** use the canonical names defined in the Standard Page Types table below. Why: Predictable file names across features.
+- `_category_.json` files **MUST** exist in every feature folder. Why: Controls sidebar rendering.
+
+## Scope and Audience
+
+All contributors writing or updating feature documentation in `docs/Docusaurus/`.
+
+## Hierarchy
+
+```
+docs/
+└── {area}/                        # e.g., event-sourcing, client-state-management
+    ├── _category_.json
+    └── {feature}/                 # e.g., brooks, aggregates, sagas
+        ├── _category_.json
+        ├── {feature}.md           # REQUIRED: Entry page (intro + getting started)
+        ├── {topic}.md             # OPTIONAL: DX-focused topic pages
+        ├── configuration.md       # OPTIONAL: Options, settings, environment setup
+        ├── testing.md             # OPTIONAL: Mocks, test utilities, test patterns
+        ├── samples.md             # OPTIONAL: Sample project links, extended examples
+        ├── public-apis.md         # OPTIONAL: API reference tables, contracts
+        ├── best-practices.md      # OPTIONAL: Performance, patterns, anti-patterns
+        ├── troubleshooting.md     # OPTIONAL: Common errors, debugging, FAQ
+        ├── internals.md           # OPTIONAL: Architecture, algorithms, design rationale
+        └── migration/             # OPTIONAL: Breaking change guides (subfolder)
+            └── v{X}-to-v{Y}.md
+```
+
+## Standard Page Types
+
+| Page | Filename | Sidebar Position | Focus | Required |
+|------|----------|------------------|-------|----------|
+| **Entry** | `{feature}.md` | 1 | Introduction, key concepts, getting started, "Learn More" links | Yes |
+| **Topic** | `{topic}.md` | 2–9 | Deep dive on specific capability (DX-focused) | As needed |
+| **Configuration** | `configuration.md` | 10 | All options, defaults, environment-specific setup | When configurable |
+| **Testing** | `testing.md` | 11 | Mocking, test utilities, test patterns, `EventSourcing.Testing` usage | When testing support exists |
+| **Samples** | `samples.md` | 12 | Links to `/samples` projects, extended code walkthroughs | When samples exist |
+| **Public APIs** | `public-apis.md` | 13 | Interface tables, contract reference, extension points | When rich API surface |
+| **Best Practices** | `best-practices.md` | 14 | Performance tips, recommended patterns, anti-patterns | When complex |
+| **Troubleshooting** | `troubleshooting.md` | 15 | Common errors, debugging tips, FAQ | When common issues exist |
+| **Internals** | `internals.md` | 16 | Architecture diagrams, algorithms, design rationale | When complex internals |
+| **Migration** | `migration/v{X}-to-v{Y}.md` | 17+ | Breaking change guides, upgrade paths | When breaking changes ship |
+
+## Entry Page Template
+
+Every feature entry page **MUST** follow this structure:
+
+```markdown
+---
+id: {feature}
+title: {Feature Title}
+sidebar_label: {Feature}
+sidebar_position: 1
+description: One-sentence summary of the feature.
+---
+
+# {Feature Title}
+
+## Overview
+
+What is this feature and why use it. State the page focus (Public API / DX).
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Term** | Definition |
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[Input] --> B[Process] --> C[Output]
+```
+
+## Getting Started
+
+### Step 1: Install
+
+### Step 2: Configure
+
+### Step 3: Use
+
+## Learn More
+
+- [Topic Page](./topic.md) - Description
+- [Configuration](./configuration.md) - Description
+```
+
+## Category JSON Template
+
+Every feature folder **MUST** include `_category_.json`:
+
+```json
+{
+  "label": "{Feature}",
+  "position": {N},
+  "collapsed": false,
+  "collapsible": true,
+  "link": {
+    "type": "doc",
+    "id": "{feature}"
+  }
+}
+```
+
+## Content Placement Guide
+
+Use this table to determine where content belongs:
+
+| Content Type | Correct Page | Never On |
+|--------------|--------------|----------|
+| "How do I mock X?" | `testing.md` | Entry, topic pages |
+| "What options does X support?" | `configuration.md` | Internals |
+| "Show me a complete project" | `samples.md` | Entry (brief examples OK) |
+| "What interfaces are available?" | `public-apis.md` | Internals |
+| "What's the recommended pattern?" | `best-practices.md` | Entry |
+| "Why am I getting error Y?" | `troubleshooting.md` | Any other page |
+| "How does X work internally?" | `internals.md` | Entry, topic pages |
+| "How do I upgrade from v1 to v2?" | `migration/v1-to-v2.md` | Any other page |
+
+## Core Principles
+
+- **One Entry Point**: The feature folder is clickable and lands on the combined intro/getting-started page.
+- **Strict Segregation**: Content lives on exactly one page type; no mixing.
+- **Progressive Disclosure**: Entry → Topics → Config → Testing → APIs → Best Practices → Troubleshooting → Internals.
+- **Predictable Names**: Same filenames across all features.
+
+## Example: Brooks Feature
+
+```
+docs/event-sourcing/brooks/
+├── _category_.json           # label: "Brooks", link to "brooks"
+├── brooks.md                 # Entry: intro, concepts, getting started
+├── brook-keys.md             # Topic: key structure and naming
+├── brook-events.md           # Topic: event envelope format
+├── reading-and-writing.md    # Topic: grain operations
+├── storage-providers.md      # Topic: storage abstraction
+├── configuration.md          # Options: provider settings, connection strings
+├── testing.md                # Testing: mocking IBrookGrainFactory
+├── samples.md                # Samples: links to Spring/LightSpeed usage
+├── public-apis.md            # APIs: all Brook interfaces and types
+├── best-practices.md         # Patterns: batching, cursor management
+├── troubleshooting.md        # Errors: common issues and fixes
+├── internals.md              # Internals: grain activation, storage mechanics
+└── migration/
+    └── v1-to-v2.md           # Breaking changes from v1 to v2
+```
+
+## References
+
+- Documentation authoring: `.github/instructions/documentation-authoring.instructions.md`
+- Page focus rules: `.github/instructions/documentation-page-focus.instructions.md`
+- Documentation guide: `docs/Docusaurus/docs/contributing/documentation-guide.md`

--- a/docs/Docusaurus/docs/contributing/documentation-guide.md
+++ b/docs/Docusaurus/docs/contributing/documentation-guide.md
@@ -125,7 +125,8 @@ flowchart LR
 
 ### Mermaid Rules
 
-- Use `flowchart LR` by default for process diagrams.
+- **MUST** use `flowchart LR` (left-to-right) by default. Why: Documentation may be viewed on mobile screens where vertical (TB) diagrams overflow and require horizontal scrolling.
+- **MUST NOT** use `flowchart TB` (top-to-bottom) unless the diagram explicitly represents a vertical hierarchy (e.g., class inheritance, call stacks) where LR would misrepresent the relationship.
 - Keep diagrams small (7 nodes or fewer) unless the doc is explicitly about architecture.
 - Prefer labels that match section terminology.
 - Do NOT embed images for diagrams.


### PR DESCRIPTION
## Business Value

Establishes consistent documentation standards for Mississippi features, ensuring:
- **Predictable navigation** - Users know where to find content across all features
- **Clear content segregation** - Testing, configuration, APIs, and internals each have designated pages
- **Mobile-friendly diagrams** - Mermaid flowcharts use LR orientation to avoid horizontal scrolling on mobile

## How It Works

### New Instruction Files

1. **[documentation-page-focus.instructions.md](.github/instructions/documentation-page-focus.instructions.md)** - Requires each doc page to declare focus as either Public API/DX or Internal Implementation
2. **[feature-documentation-structure.instructions.md](.github/instructions/feature-documentation-structure.instructions.md)** - Defines standard folder structure and page types for all features

### Standard Feature Structure

```
{area}/{feature}/
├── {feature}.md           # Entry (REQUIRED) - intro + getting started
├── {topic}.md             # DX topic pages (as needed)
├── configuration.md       # Options & settings (optional)
├── testing.md             # Mocks, test utilities (optional)
├── samples.md             # Sample project links (optional)
├── public-apis.md         # API reference (optional)
├── best-practices.md      # Patterns, anti-patterns (optional)
├── troubleshooting.md     # Errors, debugging, FAQ (optional)
├── internals.md           # Architecture, algorithms (optional)
└── migration/             # Breaking change guides (optional)
```

### Content Segregation Rules

Content MUST appear only on its designated page type:
| Content Type | Correct Page |
|--------------|--------------|
| Testing/mocking | `testing.md` |
| Configuration options | `configuration.md` |
| API reference tables | `public-apis.md` |
| Internal implementation | `internals.md` |
| Best practices | `best-practices.md` |

### Mobile-Friendly Mermaid

- **MUST** use `flowchart LR` (left-to-right) by default
- **MUST NOT** use `flowchart TB` unless representing vertical hierarchies

## Files Changed

| File | Change |
|------|--------|
| `.github/instructions/documentation-page-focus.instructions.md` | New - Page focus rules (DX vs Internals) |
| `.github/instructions/feature-documentation-structure.instructions.md` | New - Standard feature folder structure |
| `.github/instructions/documentation-authoring.instructions.md` | Added mermaid LR rule |
| `docs/Docusaurus/docs/contributing/documentation-guide.md` | Strengthened mermaid LR rule with MUST/MUST NOT |

## Quality Gates

- [x] Markdown lint passes (0 errors)
- [x] No production code changes
- [x] Follows instruction authoring conventions
