### PR TITLE
Fix labeler tests-only YAML indentation +semver: fix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -179,10 +179,11 @@ build-config:
 tests-only:
   - all:
       - changed-files:
-      - any-glob-to-any-file:
-        - 'tests/**'
-        - '!tests/**/*lock.json'
-          - all-globs-to-all-files: '!src/**'
+          - any-glob-to-any-file:
+              - 'tests/**'
+              - '!tests/**/*lock.json'
+          - all-globs-to-all-files:
+              - '!src/**'
 
 # =============================================================================
 # SAMPLE LABELS (sample:*)


### PR DESCRIPTION
## Business Value
This restores the PR labeler workflow by fixing malformed YAML in `.github/labeler.yml`, preventing workflow parse failures and ensuring labels are applied automatically.

**Key benefits:**
1. Unblocks `actions/labeler` execution.
2. Restores `tests-only` labeling behavior.
3. Prevents repeated CI failures from config syntax errors.

## Common Use Cases
| Domain | Use Case | Example |
|--------|----------|---------|
| CI Automation | Auto label PRs | Test-only PRs receive `tests-only`.

## How It Works
### Overview
Corrects the `tests-only` rule structure to valid YAML nesting under `all -> changed-files`, combining:
- `any-glob-to-any-file` for `tests/**`
- `all-globs-to-all-files` to exclude `src/**`

### Key Design Decisions
- **Minimal change**: only touched the malformed block.
- **Schema alignment**: kept existing labeler rule style.

## Observability
No runtime telemetry changes; impact is visible via successful labeler workflow runs.

## Files Changed
### Modified Files
| File | Change |
|------|--------|
| [.github/labeler.yml](.github/labeler.yml) | Fixed indentation/nesting in `tests-only` rule to valid YAML. |

## Quality Gates
- [x] YAML parse validation passes locally (`python + PyYAML`).
- [ ] Build passes with zero warnings (not applicable to this config-only change).
- [ ] All existing tests pass (not applicable to this config-only change).
- [ ] New tests added for new functionality (not applicable).

## Migration Notes
None.

## Related Issues
- Fixes workflow failure caused by YAML parsing error in `.github/labeler.yml`.
