### PR TITLE
Fix labeler.yml: separate matcher entries are OR'd, not AND'd +semver: skip

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,16 @@
 # PR Labeler configuration
 # See https://github.com/actions/labeler for documentation
 #
+# IMPORTANT: In actions/labeler v6, multiple matcher entries inside a single
+# `changed-files` list are OR'd together. This means a separate
+# `all-globs-to-any-file` block is evaluated INDEPENDENTLY — if it passes on
+# its own, the label matches regardless of the other matcher entries.
+#
+# To combine positive selection with negated exclusions, put BOTH inside the
+# SAME `any-glob-to-any-file` block. The labeler evaluates each glob in the
+# list against each changed file; a negated glob (`!pattern`) rejects the file
+# if it matches, so the net effect is "match these paths, but not lockfiles".
+#
 # Prefix taxonomy:
 #   module-*          - Core framework/module area labels
 #   sample-*          - Sample application labels
@@ -40,7 +50,6 @@ module-aqueduct:
       - any-glob-to-any-file:
           - "src/Aqueduct*/**"
           - "tests/Aqueduct*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-common:
@@ -48,7 +57,6 @@ module-common:
       - any-glob-to-any-file:
           - "src/Common*/**"
           - "tests/Common*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-event-sourcing:
@@ -56,7 +64,6 @@ module-event-sourcing:
       - any-glob-to-any-file:
           - "src/EventSourcing*/**"
           - "tests/EventSourcing*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-inlet:
@@ -64,7 +71,6 @@ module-inlet:
       - any-glob-to-any-file:
           - "src/Inlet*/**"
           - "tests/Inlet*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-refraction:
@@ -72,7 +78,6 @@ module-refraction:
       - any-glob-to-any-file:
           - "src/Refraction*/**"
           - "tests/Refraction*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-reservoir:
@@ -80,7 +85,6 @@ module-reservoir:
       - any-glob-to-any-file:
           - "src/Reservoir*/**"
           - "tests/Reservoir*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-sdk:
@@ -88,7 +92,6 @@ module-sdk:
       - any-glob-to-any-file:
           - "src/Sdk*/**"
           - "tests/Sdk*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # =============================================================================
@@ -102,7 +105,6 @@ complex-source-generation:
           - "src/Inlet.*.Generators/**"
           - "src/Inlet.Generators.*/**"
           - "tests/Inlet.*.Generators*/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # Agent/rule instructions and agent configuration
@@ -113,8 +115,6 @@ config-agentic:
           - ".github/agents/**"
           - ".cursor/**"
           - "agents.md"
-      - all-globs-to-any-file:
-          - "!**/*.lock.json"
 
 # Root build configuration (high-impact, review carefully)
 config-build:
@@ -126,8 +126,6 @@ config-build:
           - "*.slnx"
           - "stryker-config.json"
           - "GitVersion.yml"
-      - all-globs-to-any-file:
-          - "!**/*.lock.json"
 
 # Any dependency lockfile updates (*.lock.json)
 config-dependency-lock:
@@ -146,7 +144,6 @@ documentation-public-website:
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # CI/CD and automation
@@ -160,7 +157,6 @@ infra-ci-cd:
           - ".config/dotnet-tools.json"
           - "eng/**"
           - "*.ps1"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # Files changed directly in repository root (no subdirectories)
@@ -178,19 +174,16 @@ sample-crescent:
   - changed-files:
       - any-glob-to-any-file:
           - "samples/Crescent/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 sample-light-speed:
   - changed-files:
       - any-glob-to-any-file:
           - "samples/LightSpeed/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 sample-spring:
   - changed-files:
       - any-glob-to-any-file:
           - "samples/Spring/**"
-      - all-globs-to-any-file:
           - "!**/*.lock.json"


### PR DESCRIPTION
## Business Value

Every PR opened since #351 was merged gets **every label in the config** applied to it (17+ labels), making the labeling system useless. This is a production bug on `main` — every new PR will be mislabeled until this is fixed.

## The Problem

In `actions/labeler` v6, **multiple matcher entries inside a single `changed-files` list are OR'd together**, not AND'd. The previous structure (introduced in #351) placed `all-globs-to-any-file` as a **separate matcher entry** from `any-glob-to-any-file`:

```yaml
# BROKEN — the two matcher entries are OR'd
module-aqueduct:
  - changed-files:
      - any-glob-to-any-file:      # matcher entry 1
          - "src/Aqueduct*/**"
          - "tests/Aqueduct*/**"
      - all-globs-to-any-file:     # matcher entry 2 (independent OR)
          - "!**/*.lock.json"
```

The intent was: *"match files under src/Aqueduct or tests/Aqueduct, but not lockfiles."*

What actually happens:

1. **Matcher entry 1** (`any-glob-to-any-file`): Does any changed file match `src/Aqueduct*/**` or `tests/Aqueduct*/**`?
2. **Matcher entry 2** (`all-globs-to-any-file`): Does `!**/*.lock.json` match at least one changed file? → This is true for **ANY PR that touches at least one non-lockfile**, which is virtually every PR.
3. **Result**: entry 1 OR entry 2 → **always true** because entry 2 independently passes.

This pattern was repeated across all 15 labels that had lockfile exclusions, so every label matched every PR.

### Evidence

PR #352 only changes 3 files under `.github/scripts/` and `.github/workflows/`, but received 17 labels including `module-aqueduct`, `module-inlet`, `sample-spring`, etc.

## The Fix

Move the `!**/*.lock.json` negated glob **inside** the `any-glob-to-any-file` block so it acts as a filter within the same matcher, not as an independent OR'd alternative:

```yaml
# FIXED — single matcher entry, negation filters within it
module-aqueduct:
  - changed-files:
      - any-glob-to-any-file:
          - "src/Aqueduct*/**"
          - "tests/Aqueduct*/**"
          - "!**/*.lock.json"
```

Now the labeler evaluates each glob against each file within **one** matcher entry. The positive globs select files, and the negated glob rejects lockfiles — both conditions must be satisfied within the same evaluation.

For labels where the matched paths can never be `*.lock.json` files (like `config-agentic` matching `.github/instructions/**`), the lockfile exclusion was removed entirely as it was redundant.

### Labels that had the independent OR bug (all fixed):
- `module-aqueduct`, `module-common`, `module-event-sourcing`, `module-inlet`, `module-refraction`, `module-reservoir`, `module-sdk`
- `complex-source-generation`
- `config-agentic` (exclusion removed — redundant)
- `config-build` (exclusion removed — redundant)
- `documentation-public-website`
- `infra-ci-cd`
- `sample-crescent`, `sample-light-speed`, `sample-spring`

### Labels NOT affected (unchanged):
- `config-dependency-lock` — only matches `**/*.lock.json`, no exclusion needed
- `config-github` — matches `.github/**`, no exclusion was present
- `root` — matches `*` and `.*`, no exclusion was present

## Files Changed

| File | Description |
|------|-------------|
| `.github/labeler.yml` | Merged `all-globs-to-any-file` lockfile exclusions into `any-glob-to-any-file` blocks; added header comment documenting the OR semantics trap |

## Quality Gates

- [x] Change is limited to `.github/labeler.yml` (no build/test impact)
- [x] Added documentation comment to prevent future recurrence