### PR TITLE
Fix labeler.yml: use all: wrapper to AND path matchers with lockfile exclusion +semver: skip

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,30 @@
 # PR Labeler configuration
 # See https://github.com/actions/labeler for documentation
 #
-# IMPORTANT: In actions/labeler v6, multiple matcher entries inside a single
-# `changed-files` list are OR'd together. This means a separate
-# `all-globs-to-any-file` block is evaluated INDEPENDENTLY — if it passes on
-# its own, the label matches regardless of the other matcher entries.
+# IMPORTANT — actions/labeler v6 matcher semantics:
 #
-# To combine positive selection with negated exclusions, put BOTH inside the
-# SAME `any-glob-to-any-file` block. The labeler evaluates each glob in the
-# list against each changed file; a negated glob (`!pattern`) rejects the file
-# if it matches, so the net effect is "match these paths, but not lockfiles".
+#   Without an explicit `any:` or `all:` wrapper, labeler auto-wraps config
+#   entries into `any:`, which OR's all matcher entries inside `changed-files`.
+#
+#   To AND matchers (e.g. positive path selection + lockfile exclusion), you
+#   MUST use the `all:` wrapper. Under `all:`, every matcher entry inside
+#   `changed-files` must independently pass for the label to apply.
+#
+#   A negated glob like `!**/*.lock.json` inside `any-glob-to-any-file` is
+#   WRONG — it matches any non-lockfile in the entire PR, which is virtually
+#   always true, making the positive path globs irrelevant.
+#
+#   Correct pattern (from the labeler README):
+#     label:
+#       - all:
+#         - changed-files:
+#           - any-glob-to-any-file: ['src/**']       # positive selection
+#           - all-globs-to-any-file: ['!**/*.lock.json']  # exclusion filter
+#
+#   Source: https://github.com/actions/labeler/blob/main/README.md
+#   Source: https://github.com/actions/labeler/blob/main/src/changedFiles.ts
+#     - checkAnyChangedFiles: OR's configs (used under `any:`)
+#     - checkAllChangedFiles: AND's configs (used under `all:`)
 #
 # Prefix taxonomy:
 #   module-*          - Core framework/module area labels
@@ -43,55 +58,71 @@
 
 # =============================================================================
 # MODULE LABELS
+# Labels that use `all:` to AND positive path matching with lockfile exclusion.
+# This ensures lockfile-only changes don't trigger module labels.
 # =============================================================================
 
 module-aqueduct:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Aqueduct*/**"
           - "tests/Aqueduct*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-common:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Common*/**"
           - "tests/Common*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-event-sourcing:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/EventSourcing*/**"
           - "tests/EventSourcing*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-inlet:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Inlet*/**"
           - "tests/Inlet*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-refraction:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Refraction*/**"
           - "tests/Refraction*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-reservoir:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Reservoir*/**"
           - "tests/Reservoir*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-sdk:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Sdk*/**"
           - "tests/Sdk*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # =============================================================================
@@ -100,14 +131,17 @@ module-sdk:
 
 # Source generators deserve special attention (complex, affects DX)
 complex-source-generation:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Inlet.*.Generators/**"
           - "src/Inlet.Generators.*/**"
           - "tests/Inlet.*.Generators*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # Agent/rule instructions and agent configuration
+# No lockfile exclusion needed — these paths never contain *.lock.json
 config-agentic:
   - changed-files:
       - any-glob-to-any-file:
@@ -117,6 +151,7 @@ config-agentic:
           - "agents.md"
 
 # Root build configuration (high-impact, review carefully)
+# No lockfile exclusion needed — explicit file names, none are lockfiles
 config-build:
   - changed-files:
       - any-glob-to-any-file:
@@ -141,14 +176,17 @@ config-github:
 
 # Matches GitHub's default 'documentation' label
 documentation-public-website:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # CI/CD and automation
 infra-ci-cd:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - ".github/workflows/**"
           - ".github/actions/**"
@@ -157,6 +195,7 @@ infra-ci-cd:
           - ".config/dotnet-tools.json"
           - "eng/**"
           - "*.ps1"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # Files changed directly in repository root (no subdirectories)
@@ -171,19 +210,25 @@ root:
 # =============================================================================
 
 sample-crescent:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "samples/Crescent/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 sample-light-speed:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "samples/LightSpeed/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 sample-spring:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "samples/Spring/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"


### PR DESCRIPTION
## Business Value

The PR labeler is still broken on main — every PR gets every label applied. This makes the label system useless for filtering, triaging, and automation. This is the third attempt; the first two failed because of a subtle but well-documented behavior in `actions/labeler` v6.

## What Went Wrong (Twice)

### Attempt 1 (PR #351 — merged)

Placed `any-glob-to-any-file` and `all-globs-to-any-file` as **separate matcher entries** inside `changed-files`:

```yaml
module-aqueduct:
  - changed-files:
      - any-glob-to-any-file:         # matcher entry 1 (OR'd)
          - "src/Aqueduct*/**"
      - all-globs-to-any-file:        # matcher entry 2 (OR'd)
          - "!**/*.lock.json"
```

**Why it failed**: Without an explicit `any:` or `all:` wrapper, labeler auto-wraps entries into `any:` ([source](https://github.com/actions/labeler/blob/main/src/api/get-label-configs.ts#L75-L82)). Under `any:`, `checkAnyChangedFiles` OR's the matcher entries — if **either** passes, the label applies. Since `!**/*.lock.json` independently matches any PR with at least one non-lockfile (which is every PR), every label matched every PR.

### Attempt 2 (PR #353 — merged)

Moved the negated glob **inside** the `any-glob-to-any-file` block:

```yaml
module-aqueduct:
  - changed-files:
      - any-glob-to-any-file:
          - "src/Aqueduct*/**"
          - "tests/Aqueduct*/**"
          - "!**/*.lock.json"          # still wrong!
```

**Why it failed**: `any-glob-to-any-file` means "does **ANY** glob match **ANY** file?" The negated glob `!**/*.lock.json` matches any non-lockfile in the entire PR — e.g., `.github/scripts/foo.cs` passes the glob even though it has nothing to do with `src/Aqueduct`. The positive path globs become irrelevant because the negated glob independently satisfies the condition.

### This PR (Attempt 3) — correct

Uses the `all:` wrapper to **AND** the positive path matcher with the lockfile exclusion:

```yaml
module-aqueduct:
  - all:
    - changed-files:
      - any-glob-to-any-file:
          - "src/Aqueduct*/**"
          - "tests/Aqueduct*/**"
      - all-globs-to-any-file:
          - "!**/*.lock.json"
```

Under `all:`, `checkAllChangedFiles` requires **ALL** matcher entries to pass ([source](https://github.com/actions/labeler/blob/main/src/changedFiles.ts#L94-L135)):
1. `any-glob-to-any-file` — at least one changed file matches a module path
2. `all-globs-to-any-file` — at least one changed file is NOT a lockfile

Both must be true. This matches the pattern from the [labeler README](https://github.com/actions/labeler/blob/main/README.md):

```yaml
source:
- all:
  - changed-files:
    - any-glob-to-any-file: 'src/**/*'
    - all-globs-to-all-files: '!src/docs/*'
```

## How It Works — Source Code Evidence

From `actions/labeler` source:

| Function | Behavior | Used under |
|----------|----------|------------|
| `checkAnyChangedFiles` | Returns `true` if **ANY** config check passes (OR) | `any:` (default) |
| `checkAllChangedFiles` | Returns `false` if **ANY** config check fails (AND) | `all:` |

Key code from [`changedFiles.ts`](https://github.com/actions/labeler/blob/main/src/changedFiles.ts):
- `checkAnyChangedFiles`: loops over configs, returns `true` on first match
- `checkAllChangedFiles`: loops over configs, returns `false` on first failure

Key code from [`get-label-configs.ts`](https://github.com/actions/labeler/blob/main/src/api/get-label-configs.ts):
- When no `any:`/`all:` wrapper is present, entries are auto-pushed into `any:` (line ~80)

Related issue: [actions/labeler#883 — "file exclusion does not work"](https://github.com/actions/labeler/issues/883)

## Evaluation Traces

### PR with only `.github/scripts/foo.cs` (should NOT get `module-aqueduct`)

**Old (broken)**:
- `any-glob-to-any-file: ["src/Aqueduct*/**", ..., "!**/*.lock.json"]`
- `!**/*.lock.json` matches `foo.cs` → **TRUE** → label applied ❌

**New (fixed)**:
- `all:` requires ALL to pass:
  - `any-glob-to-any-file: ["src/Aqueduct*/**", ...]` → no match → **FALSE**
- Short-circuit: label NOT applied ✅

### PR with `src/Aqueduct/Foo.cs` (should get `module-aqueduct`)

- `all:` requires ALL to pass:
  - `any-glob-to-any-file` → `src/Aqueduct*/**` matches → **TRUE**
  - `all-globs-to-any-file` → `!**/*.lock.json` matches `Foo.cs` → **TRUE**
- Both pass → label applied ✅

### PR with only `src/Aqueduct/packages.lock.json` (should NOT get `module-aqueduct`)

- `all:` requires ALL to pass:
  - `any-glob-to-any-file` → `src/Aqueduct*/**` matches → **TRUE**
  - `all-globs-to-any-file` → `!**/*.lock.json` matches nothing (only file is lockfile) → **FALSE**
- Second fails → label NOT applied ✅

## Files Changed

| File | Description |
|------|-------------|
| `.github/labeler.yml` | Wrapped 13 labels in `all:` to AND positive path matching with lockfile exclusion; updated header comment with source code references and correct pattern documentation |

### Labels wrapped in `all:` (lockfile exclusion needed):
`module-aqueduct`, `module-common`, `module-event-sourcing`, `module-inlet`, `module-refraction`, `module-reservoir`, `module-sdk`, `complex-source-generation`, `documentation-public-website`, `infra-ci-cd`, `sample-crescent`, `sample-light-speed`, `sample-spring`

### Labels unchanged (no lockfile exclusion needed):
`config-agentic`, `config-build`, `config-dependency-lock`, `config-github`, `root`

## Quality Gates

- [x] Change limited to `.github/labeler.yml` — no build/test impact
- [x] Verified against labeler source code (changedFiles.ts, get-label-configs.ts, labeler.ts)
- [x] Matches the documented pattern from the labeler README
- [x] Header comment updated with correct semantics, source links, and example pattern