### PR TITLE
Fix labeler.yml: use all: wrapper to AND path matchers with lockfile exclusion +semver: skip

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,39 @@
 # PR Labeler configuration
 # See https://github.com/actions/labeler for documentation
 #
-# IMPORTANT: In actions/labeler v6, multiple matcher entries inside a single
-# `changed-files` list are OR'd together. This means a separate
-# `all-globs-to-any-file` block is evaluated INDEPENDENTLY — if it passes on
-# its own, the label matches regardless of the other matcher entries.
+# IMPORTANT — actions/labeler v6 matcher semantics:
 #
-# To combine positive selection with negated exclusions, put BOTH inside the
-# SAME `any-glob-to-any-file` block. The labeler evaluates each glob in the
-# list against each changed file; a negated glob (`!pattern`) rejects the file
-# if it matches, so the net effect is "match these paths, but not lockfiles".
+#   1. Without an explicit `any:` or `all:` wrapper, labeler auto-wraps config
+#      entries into `any:`, which OR's all matcher entries inside `changed-files`.
+#      Source: get-label-configs.ts lines 75-82
+#      https://github.com/actions/labeler/blob/main/src/api/get-label-configs.ts
+#
+#   2. Under `any:`, checkAnyChangedFiles OR's each config — if ANY passes,
+#      the label applies.
+#      Source: changedFiles.ts checkAnyChangedFiles function
+#      https://github.com/actions/labeler/blob/main/src/changedFiles.ts
+#
+#   3. Under `all:`, checkAllChangedFiles AND's each config — ALL must pass.
+#      Source: changedFiles.ts checkAllChangedFiles function
+#      https://github.com/actions/labeler/blob/main/src/changedFiles.ts
+#
+#   4. A negated glob like `!**/*.lock.json` inside `any-glob-to-any-file` is
+#      WRONG — `any-glob-to-any-file` asks "does ANY glob match ANY file?", so
+#      the negated glob independently matches ANY non-lockfile in the entire PR,
+#      making positive path globs irrelevant.
+#
+#   5. A negated glob as a separate `all-globs-to-any-file` entry without `all:`
+#      is also WRONG — without `all:` it's auto-wrapped in `any:` and OR'd.
+#
+#   Correct pattern (from the labeler README):
+#     label:
+#       - all:                                         # <-- AND wrapper
+#         - changed-files:
+#           - any-glob-to-any-file: ['src/**']         # positive selection
+#           - all-globs-to-any-file: ['!**/docs/*']    # exclusion filter
+#
+#   README: https://github.com/actions/labeler/blob/main/README.md
+#   Related issue: https://github.com/actions/labeler/issues/883
 #
 # Prefix taxonomy:
 #   module-*          - Core framework/module area labels
@@ -43,55 +67,74 @@
 
 # =============================================================================
 # MODULE LABELS
+#
+# Use `all:` to AND the positive path matcher with the lockfile exclusion.
+# Under `all:`, checkAllChangedFiles requires BOTH to independently pass:
+#   1. any-glob-to-any-file: at least one file matches a module path
+#   2. all-globs-to-any-file: at least one file is NOT a lockfile
 # =============================================================================
 
 module-aqueduct:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Aqueduct*/**"
           - "tests/Aqueduct*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-common:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Common*/**"
           - "tests/Common*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-event-sourcing:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/EventSourcing*/**"
           - "tests/EventSourcing*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-inlet:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Inlet*/**"
           - "tests/Inlet*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-refraction:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Refraction*/**"
           - "tests/Refraction*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-reservoir:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Reservoir*/**"
           - "tests/Reservoir*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 module-sdk:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Sdk*/**"
           - "tests/Sdk*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # =============================================================================
@@ -100,14 +143,17 @@ module-sdk:
 
 # Source generators deserve special attention (complex, affects DX)
 complex-source-generation:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "src/Inlet.*.Generators/**"
           - "src/Inlet.Generators.*/**"
           - "tests/Inlet.*.Generators*/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # Agent/rule instructions and agent configuration
+# No lockfile exclusion needed — these paths can never be *.lock.json
 config-agentic:
   - changed-files:
       - any-glob-to-any-file:
@@ -117,6 +163,7 @@ config-agentic:
           - "agents.md"
 
 # Root build configuration (high-impact, review carefully)
+# No lockfile exclusion needed — explicit file names, none are lockfiles
 config-build:
   - changed-files:
       - any-glob-to-any-file:
@@ -141,14 +188,17 @@ config-github:
 
 # Matches GitHub's default 'documentation' label
 documentation-public-website:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # CI/CD and automation
 infra-ci-cd:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - ".github/workflows/**"
           - ".github/actions/**"
@@ -157,6 +207,7 @@ infra-ci-cd:
           - ".config/dotnet-tools.json"
           - "eng/**"
           - "*.ps1"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 # Files changed directly in repository root (no subdirectories)
@@ -171,19 +222,25 @@ root:
 # =============================================================================
 
 sample-crescent:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "samples/Crescent/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 sample-light-speed:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "samples/LightSpeed/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"
 
 sample-spring:
-  - changed-files:
+  - all:
+    - changed-files:
       - any-glob-to-any-file:
           - "samples/Spring/**"
+      - all-globs-to-any-file:
           - "!**/*.lock.json"


### PR DESCRIPTION
## Business Value

Every PR currently gets **all** labels applied. This is the third fix attempt — the previous two (#351, #353) both failed due to misunderstanding how `actions/labeler` v6 evaluates matcher entries. This PR fixes the root cause with evidence from the labeler's source code and a local simulation that proves correctness.

## Root Cause Analysis

### Why the original config (#351) was wrong

```yaml
# TWO separate entries under changed-files — auto-wrapped into any: (OR)
module-aqueduct:
  - changed-files:
    - any-glob-to-any-file:
        - "src/Aqueduct*/**"
    - all-globs-to-any-file:
        - "!**/*.lock.json"
```

Without an explicit `any:` or `all:` wrapper, `actions/labeler` v6 auto-wraps entries into `any:` ([source: `get-label-configs.ts` lines 75-82](https://github.com/actions/labeler/blob/main/src/api/get-label-configs.ts#L75-L82)):

```typescript
} else if (ALLOWED_CONFIG_KEYS.includes(key)) {
  const newMatchConfig = toMatchConfig({[key]: value});
  updatedConfig.push({any: [newMatchConfig]});
}
```

Under `any:`, [`checkAnyChangedFiles`](https://github.com/actions/labeler/blob/main/src/changedFiles.ts) returns `true` if **ANY** config check passes. So the `all-globs-to-any-file: ["!**/*.lock.json"]` entry independently matches any PR that contains at least one non-lockfile — which is virtually every PR.

### Why the first fix (#353) was also wrong

```yaml
# Negated glob INSIDE any-glob-to-any-file — still wrong
module-aqueduct:
  - changed-files:
    - any-glob-to-any-file:
        - "src/Aqueduct*/**"
        - "!**/*.lock.json"
```

[`any-glob-to-any-file`](https://github.com/actions/labeler/blob/main/src/changedFiles.ts) means "does **ANY** glob match **ANY** file?" via `checkIfAnyGlobMatchesAnyFile`. The negated glob `!**/*.lock.json` matches any file that isn't a lockfile — so if the PR contains *any* non-lockfile (e.g., `.github/workflows/ci.yml`), the negated glob matches it, and the whole label applies regardless of path.

### Why this fix is correct

```yaml
# all: wrapper AND's the two matchers
module-aqueduct:
  - all:
    - changed-files:
      - any-glob-to-any-file:
          - "src/Aqueduct*/**"
          - "tests/Aqueduct*/**"
      - all-globs-to-any-file:
          - "!**/*.lock.json"
```

Under `all:`, [`checkAllChangedFiles`](https://github.com/actions/labeler/blob/main/src/changedFiles.ts) requires **ALL** config checks to pass:

1. `any-glob-to-any-file` → At least one changed file must match `src/Aqueduct*/**` or `tests/Aqueduct*/**`
2. `all-globs-to-any-file: ["!**/*.lock.json"]` → At least one changed file must NOT be a lockfile

Both must independently pass. This correctly handles:

| Scenario | `any-glob-to-any-file` | `all-globs-to-any-file` | Label? |
|---|---|---|---|
| Only `.github/scripts/foo.cs` | ❌ (no Aqueduct path) | ✅ | **No** ✅ |
| Only `src/Aqueduct/Foo.cs` | ✅ | ✅ (Foo.cs isn't lockfile) | **Yes** ✅ |
| Only `src/Aqueduct/packages.lock.json` | ✅ | ❌ (only file is lockfile) | **No** ✅ |
| `src/Aqueduct/Foo.cs` + lockfile | ✅ | ✅ (Foo.cs isn't lockfile) | **Yes** ✅ |
| Only `docs/foo.md` | ❌ | ✅ | **No** ✅ |
| Only `samples/Spring/Foo.cs` | ❌ | ✅ | **No** ✅ |
| Only `samples/Spring/packages.lock.json` | ❌ | ❌ | **No** ✅ |

### Local simulation proof

Built a Python simulation that faithfully reimplements the labeler's TypeScript logic (`checkIfAnyGlobMatchesAnyFile`, `checkIfAllGlobsMatchAnyFile`, `checkAnyChangedFiles`, `checkAllChangedFiles`) and tested all 7 scenarios above against both the broken (PR #353) and fixed configs:

- **Broken config (PR #353)**: 5 of 7 scenarios produce wrong results (false positives)
- **Fixed config (this PR)**: 7 of 7 scenarios produce correct results

## Source Code References

These are the exact source files we traced through to understand the bug:

1. [`actions/labeler/src/api/get-label-configs.ts`](https://github.com/actions/labeler/blob/main/src/api/get-label-configs.ts) — Auto-wraps unnamed entries into `any:` (lines 75-82)
2. [`actions/labeler/src/changedFiles.ts`](https://github.com/actions/labeler/blob/main/src/changedFiles.ts) — `checkAnyChangedFiles` (OR) vs `checkAllChangedFiles` (AND)
3. [`actions/labeler/src/labeler.ts`](https://github.com/actions/labeler/blob/main/src/labeler.ts) — `checkMatch` dispatches to `checkAll`/`checkAny`
4. [`actions/labeler README.md`](https://github.com/actions/labeler/blob/main/README.md) — Documents the `all:` wrapper pattern with exclusions
5. [`actions/labeler#883`](https://github.com/actions/labeler/issues/883) — Another user hit the exact same problem and solved it with `all:`

## What Changed

All 13 labels that need lockfile exclusion now use the `all:` wrapper:

- `module-aqueduct`, `module-common`, `module-event-sourcing`, `module-inlet`, `module-refraction`, `module-reservoir`, `module-sdk`
- `complex-source-generation`, `documentation-public-website`, `infra-ci-cd`
- `sample-crescent`, `sample-light-speed`, `sample-spring`

5 labels remain unchanged (no lockfile exclusion needed):
- `config-agentic`, `config-build`, `config-dependency-lock`, `config-github`, `root`

Header comment updated with numbered source references.

## Files Changed

| File | Change |
|---|---|
| `.github/labeler.yml` | Wrap 13 labels in `all:` to AND path matchers with lockfile exclusion |

## Quality Gates

- [x] Single-responsibility change (labeler config only)
- [x] Root cause traced to labeler source code with links
- [x] Local simulation proves all 7 test scenarios pass
- [x] No production code affected

## Related Issues

- Supersedes #354 (same fix idea, not merged)
- Follow-up: #352 (backfill workflow) should be rebased after this merges