### PR TITLE
Test: verify labeler applies only module-event-sourcing label +semver: skip

### DIFF
--- a/src/EventSourcing.Aggregates/EventTypeRegistry.cs
+++ b/src/EventSourcing.Aggregates/EventTypeRegistry.cs
@@ -11,7 +11,7 @@ namespace Mississippi.EventSourcing.Aggregates;
 
 /// <summary>
 ///     Default implementation of <see cref="IEventTypeRegistry" /> providing bidirectional
-///     event name ↔ CLR type resolution with O(1) lookup performance.
+///     event name ↔ CLR type resolution with O(1) lookup performance via concurrent dictionaries.
 /// </summary>
 /// <remarks>
 ///     <para>


### PR DESCRIPTION
## Purpose

Test PR to verify that the labeler correctly applies labels after the `all:` wrapper fix (#355).

**Changed file**: `src/EventSourcing.Aggregates/EventTypeRegistry.cs` (trivial XML doc comment edit)

## Expected Labels

| Label | Should Apply? | Why |
|---|---|---|
| `module-event-sourcing` | **Yes** | File matches `src/EventSourcing*/**` and is not a lockfile |
| `semver:skip` | **Yes** | PR title ends with `+semver: skip` |
| `module-aqueduct` | No | No files in `src/Aqueduct*/**` or `tests/Aqueduct*/**` |
| `module-common` | No | No files in `src/Common*/**` |
| `sample-*` | No | No files in `samples/**` |
| `documentation-public-website` | No | No files in `docs/**` |
| `config-dependency-lock` | No | No `*.lock.json` files changed |
| `infra-ci-cd` | No | No workflow/eng/script files changed |

## Verdict

If only `module-event-sourcing` and `semver:skip` appear, the labeler is working correctly. Close this PR after verification.