### PR TITLE
Add manual saga continue command for UX-triggered resume +semver: feature

### DIFF
--- a/src/EventSourcing.Sagas.Abstractions/ContinueSagaCommand.cs
+++ b/src/EventSourcing.Sagas.Abstractions/ContinueSagaCommand.cs
@@ -1,0 +1,26 @@
+using System;
+
+using Orleans;
+
+
+namespace Mississippi.EventSourcing.Sagas.Abstractions;
+
+/// <summary>
+///     Command that requests manual saga resume from a client or UX action.
+/// </summary>
+[GenerateSerializer]
+[Alias("Mississippi.EventSourcing.Sagas.Abstractions.ContinueSagaCommand")]
+public sealed record ContinueSagaCommand
+{
+    /// <summary>
+    ///     Gets the optional correlation identifier.
+    /// </summary>
+    [Id(1)]
+    public string? CorrelationId { get; init; }
+
+    /// <summary>
+    ///     Gets the saga identifier.
+    /// </summary>
+    [Id(0)]
+    public required Guid SagaId { get; init; }
+}

--- a/src/EventSourcing.Sagas.Abstractions/SagaResumeRequested.cs
+++ b/src/EventSourcing.Sagas.Abstractions/SagaResumeRequested.cs
@@ -1,0 +1,35 @@
+using System;
+
+using Mississippi.EventSourcing.Brooks.Abstractions.Attributes;
+
+using Orleans;
+
+
+namespace Mississippi.EventSourcing.Sagas.Abstractions;
+
+/// <summary>
+///     Event emitted when manual saga resume is requested.
+/// </summary>
+[GenerateSerializer]
+[Alias("Mississippi.EventSourcing.Sagas.Abstractions.SagaResumeRequested")]
+[EventStorageName("MISSISSIPPI", "SAGAS", "SAGARESUMEREQUESTED")]
+public sealed record SagaResumeRequested
+{
+    /// <summary>
+    ///     Gets the optional correlation identifier.
+    /// </summary>
+    [Id(1)]
+    public string? CorrelationId { get; init; }
+
+    /// <summary>
+    ///     Gets the timestamp when resume was requested.
+    /// </summary>
+    [Id(2)]
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>
+    ///     Gets the saga identifier.
+    /// </summary>
+    [Id(0)]
+    public required Guid SagaId { get; init; }
+}

--- a/src/EventSourcing.Sagas/ContinueSagaCommandHandler.cs
+++ b/src/EventSourcing.Sagas/ContinueSagaCommandHandler.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+using Mississippi.EventSourcing.Aggregates.Abstractions;
+using Mississippi.EventSourcing.Sagas.Abstractions;
+
+
+namespace Mississippi.EventSourcing.Sagas;
+
+/// <summary>
+///     Handles manual saga resume commands by emitting <see cref="SagaResumeRequested" />.
+/// </summary>
+/// <typeparam name="TSaga">The saga state type.</typeparam>
+public sealed class ContinueSagaCommandHandler<TSaga> : CommandHandlerBase<ContinueSagaCommand, TSaga>
+    where TSaga : class, ISagaState
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ContinueSagaCommandHandler{TSaga}" /> class.
+    /// </summary>
+    /// <param name="timeProvider">The time provider.</param>
+    public ContinueSagaCommandHandler(
+        TimeProvider timeProvider
+    )
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        TimeProvider = timeProvider;
+    }
+
+    private TimeProvider TimeProvider { get; }
+
+    /// <inheritdoc />
+    protected override OperationResult<IReadOnlyList<object>> HandleCore(
+        ContinueSagaCommand command,
+        TSaga? state
+    )
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (state is null || state.Phase == SagaPhase.NotStarted)
+        {
+            return OperationResult.Fail<IReadOnlyList<object>>(
+                AggregateErrorCodes.InvalidState,
+                $"Saga '{typeof(TSaga).Name}' has not started.");
+        }
+
+        SagaResumeRequested resumeRequested = new()
+        {
+            SagaId = command.SagaId,
+            CorrelationId = command.CorrelationId,
+            RequestedAt = TimeProvider.GetUtcNow(),
+        };
+
+        return OperationResult.Ok<IReadOnlyList<object>>([resumeRequested]);
+    }
+}

--- a/src/EventSourcing.Sagas/SagaOrchestrationEffect.cs
+++ b/src/EventSourcing.Sagas/SagaOrchestrationEffect.cs
@@ -58,7 +58,7 @@ public sealed class SagaOrchestrationEffect<TSaga> : IEventEffect<TSaga>
     {
         ArgumentNullException.ThrowIfNull(eventData);
         return eventData is SagaStartedEvent or SagaStepCompleted or SagaStepFailed or SagaCompensating
-            or SagaStepCompensated;
+            or SagaStepCompensated or SagaResumeRequested;
     }
 
     /// <inheritdoc />
@@ -71,6 +71,7 @@ public sealed class SagaOrchestrationEffect<TSaga> : IEventEffect<TSaga>
     )
     {
         ArgumentNullException.ThrowIfNull(eventData);
+        ArgumentNullException.ThrowIfNull(currentState);
         return eventData switch
         {
             SagaStartedEvent => ExecuteStepAsync(currentState, 0, cancellationToken),
@@ -87,8 +88,36 @@ public sealed class SagaOrchestrationEffect<TSaga> : IEventEffect<TSaga>
                 currentState,
                 compensated.StepIndex,
                 cancellationToken),
+            SagaResumeRequested => ExecuteResumeAsync(currentState, cancellationToken),
             var _ => AsyncEnumerable.Empty<object>(),
         };
+    }
+
+    private async IAsyncEnumerable<object> ExecuteResumeAsync(
+        TSaga state,
+        [EnumeratorCancellation] CancellationToken cancellationToken
+    )
+    {
+        switch (state.Phase)
+        {
+            case SagaPhase.Running:
+            case SagaPhase.Failed:
+                await foreach (object evt in ExecuteStepAsync(state, state.LastCompletedStepIndex + 1, cancellationToken))
+                {
+                    yield return evt;
+                }
+
+                break;
+            case SagaPhase.Compensating:
+                await foreach (object evt in ExecuteCompensationAsync(state, state.LastCompletedStepIndex, cancellationToken))
+                {
+                    yield return evt;
+                }
+
+                break;
+            default:
+                yield break;
+        }
     }
 
     private async IAsyncEnumerable<object> ExecuteCompensationAsync(

--- a/src/EventSourcing.Sagas/SagaRegistrations.cs
+++ b/src/EventSourcing.Sagas/SagaRegistrations.cs
@@ -35,10 +35,12 @@ public static class SagaRegistrations
         services.AddEventType<SagaStepFailed>();
         services.AddEventType<SagaCompensating>();
         services.AddEventType<SagaStepCompensated>();
+        services.AddEventType<SagaResumeRequested>();
         services.AddEventType<SagaCompleted>();
         services.AddEventType<SagaCompensated>();
         services.AddEventType<SagaFailed>();
         services.AddCommandHandler<StartSagaCommand<TInput>, TSaga, StartSagaCommandHandler<TSaga, TInput>>();
+        services.AddCommandHandler<ContinueSagaCommand, TSaga, ContinueSagaCommandHandler<TSaga>>();
         services.AddReducer<SagaStartedEvent, TSaga, SagaStartedReducer<TSaga>>();
         services.AddReducer<SagaInputProvided<TInput>, TSaga, SagaInputProvidedReducer<TSaga, TInput>>();
         services.AddReducer<SagaStepCompleted, TSaga, SagaStepCompletedReducer<TSaga>>();

--- a/tests/EventSourcing.Sagas.L0Tests/ContinueSagaCommandHandlerTests.cs
+++ b/tests/EventSourcing.Sagas.L0Tests/ContinueSagaCommandHandlerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Time.Testing;
+
+using Mississippi.EventSourcing.Aggregates.Abstractions;
+using Mississippi.EventSourcing.Sagas.Abstractions;
+
+
+namespace Mississippi.EventSourcing.Sagas.L0Tests;
+
+/// <summary>
+///     Tests for <see cref="ContinueSagaCommandHandler{TSaga}" />.
+/// </summary>
+public sealed class ContinueSagaCommandHandlerTests
+{
+    /// <summary>
+    ///     Verifies handler fails when saga has not started.
+    /// </summary>
+    [Fact]
+    public void HandleFailsWhenSagaNotStarted()
+    {
+        ContinueSagaCommandHandler<TestSagaState> handler = new(new FakeTimeProvider());
+        ContinueSagaCommand command = new()
+        {
+            SagaId = Guid.NewGuid(),
+            CorrelationId = "corr-1",
+        };
+
+        OperationResult<IReadOnlyList<object>> result = handler.Handle(command, null);
+
+        Assert.False(result.Success);
+        Assert.Equal(AggregateErrorCodes.InvalidState, result.ErrorCode);
+    }
+
+    /// <summary>
+    ///     Verifies handler emits resume-requested event for started saga.
+    /// </summary>
+    [Fact]
+    public void HandleReturnsSagaResumeRequested()
+    {
+        DateTimeOffset now = new(2025, 2, 20, 12, 0, 0, TimeSpan.Zero);
+        FakeTimeProvider timeProvider = new(now);
+        ContinueSagaCommandHandler<TestSagaState> handler = new(timeProvider);
+        ContinueSagaCommand command = new()
+        {
+            SagaId = Guid.NewGuid(),
+            CorrelationId = "corr-2",
+        };
+        TestSagaState state = new()
+        {
+            SagaId = command.SagaId,
+            Phase = SagaPhase.Failed,
+            LastCompletedStepIndex = 0,
+        };
+
+        OperationResult<IReadOnlyList<object>> result = handler.Handle(command, state);
+
+        Assert.True(result.Success);
+        SagaResumeRequested resumeRequested = Assert.IsType<SagaResumeRequested>(Assert.Single(result.Value));
+        Assert.Equal(command.SagaId, resumeRequested.SagaId);
+        Assert.Equal(command.CorrelationId, resumeRequested.CorrelationId);
+        Assert.Equal(now, resumeRequested.RequestedAt);
+    }
+}

--- a/tests/EventSourcing.Sagas.L0Tests/SagaOrchestrationEffectTests.cs
+++ b/tests/EventSourcing.Sagas.L0Tests/SagaOrchestrationEffectTests.cs
@@ -116,7 +116,91 @@ public sealed class SagaOrchestrationEffectTests
                     StepIndex = 0,
                     StepName = "Step",
                 }));
+        Assert.True(
+            effect.CanHandle(
+                new SagaResumeRequested
+                {
+                    SagaId = Guid.NewGuid(),
+                    RequestedAt = now,
+                }));
         Assert.False(effect.CanHandle(new()));
+    }
+
+    /// <summary>
+    ///     Verifies manual resume in failed phase executes the next step.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsyncResumesNextStepWhenResumeRequestedInFailedPhase()
+    {
+        DateTimeOffset now = new(2025, 2, 20, 13, 0, 0, TimeSpan.Zero);
+        FakeTimeProvider timeProvider = new(now);
+        SagaStepInfo[] steps =
+        [
+            new(0, "Debit", typeof(SagaSuccessStep), false),
+            new(1, "Credit", typeof(SagaSuccessStep), false),
+        ];
+        using ServiceProvider provider = CreateProvider(services => services.AddTransient<SagaSuccessStep>());
+        SagaOrchestrationEffect<TestSagaState> effect = CreateEffect(steps, provider, timeProvider);
+        TestSagaState state = new()
+        {
+            Phase = SagaPhase.Failed,
+            LastCompletedStepIndex = 0,
+        };
+
+        List<object> events = await CollectAsync(
+            effect.HandleAsync(
+                new SagaResumeRequested
+                {
+                    SagaId = Guid.NewGuid(),
+                    RequestedAt = now,
+                },
+                state,
+                "saga",
+                0,
+                CancellationToken.None));
+
+        Assert.Collection(
+            events,
+            item => Assert.IsType<SagaMarkerEvent>(item),
+            item =>
+            {
+                SagaStepCompleted completed = Assert.IsType<SagaStepCompleted>(item);
+                Assert.Equal(1, completed.StepIndex);
+                Assert.Equal("Credit", completed.StepName);
+                Assert.Equal(now, completed.CompletedAt);
+            });
+    }
+
+    /// <summary>
+    ///     Verifies manual resume in completed phase is a no-op.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsyncReturnsNoEventsWhenResumeRequestedInCompletedPhase()
+    {
+        DateTimeOffset now = new(2025, 2, 20, 14, 0, 0, TimeSpan.Zero);
+        using ServiceProvider provider = CreateProvider();
+        SagaOrchestrationEffect<TestSagaState> effect = CreateEffect(Array.Empty<SagaStepInfo>(), provider);
+        TestSagaState state = new()
+        {
+            Phase = SagaPhase.Completed,
+            LastCompletedStepIndex = 0,
+        };
+
+        List<object> events = await CollectAsync(
+            effect.HandleAsync(
+                new SagaResumeRequested
+                {
+                    SagaId = Guid.NewGuid(),
+                    RequestedAt = now,
+                },
+                state,
+                "saga",
+                0,
+                CancellationToken.None));
+
+        Assert.Empty(events);
     }
 
     /// <summary>

--- a/tests/EventSourcing.Sagas.L0Tests/SagaRegistrationsTests.cs
+++ b/tests/EventSourcing.Sagas.L0Tests/SagaRegistrationsTests.cs
@@ -1,5 +1,4 @@
 using System;
-
 using Microsoft.Extensions.DependencyInjection;
 
 using Mississippi.EventSourcing.Aggregates.Abstractions;
@@ -27,6 +26,35 @@ public sealed class SagaRegistrationsTests
         IEventTypeRegistry registry = provider.GetRequiredService<IEventTypeRegistry>();
         string? eventName = registry.ResolveName(typeof(SagaInputProvided<TestInput>));
         Assert.NotNull(eventName);
+    }
+
+    /// <summary>
+    ///     Verifies saga resume requested event type is registered.
+    /// </summary>
+    [Fact]
+    public void AddSagaOrchestrationRegistersSagaResumeRequestedEventType()
+    {
+        ServiceCollection services = new();
+        services.AddSagaOrchestration<TestSagaState, TestInput>();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IEventTypeRegistry registry = provider.GetRequiredService<IEventTypeRegistry>();
+        string? eventName = registry.ResolveName(typeof(SagaResumeRequested));
+        Assert.NotNull(eventName);
+    }
+
+    /// <summary>
+    ///     Verifies continue-saga command handler is registered.
+    /// </summary>
+    [Fact]
+    public void AddSagaOrchestrationRegistersContinueSagaCommandHandler()
+    {
+        ServiceCollection services = new();
+        services.AddSagaOrchestration<TestSagaState, TestInput>();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        ICommandHandler<ContinueSagaCommand, TestSagaState>? handler = provider
+            .GetService<ICommandHandler<ContinueSagaCommand, TestSagaState>>();
+        Assert.NotNull(handler);
+        Assert.IsType<ContinueSagaCommandHandler<TestSagaState>>(handler);
     }
 
     /// <summary>


### PR DESCRIPTION
# Add manual saga continue command for UX-triggered resume

## Business Value

This adds a safe, explicit recovery lever when a saga stalls or fails: operators/UX can manually trigger resume through a built-in command without waiting for scheduler rollout.

**Key benefits:**

1. Restores progress for stuck saga instances via command API.
2. Unblocks manual operational recovery workflows in UX/client.
3. Provides phase-2 saga-resume foundation while keeping scope small.

## Common Use Cases

| Domain | Use Case | Example |
|--------|----------|---------|
| Operations | Recover stalled saga | Support user clicks "Resume" in admin UX for a stuck transfer saga |
| Reliability | Retry after transient step failure | Saga marked failed due to transient dependency is resumed manually |
| Incident response | Controlled remediation | On-call resumes affected saga instances after downstream outage |

## How It Works

### Overview

A new `ContinueSagaCommand` is handled by `ContinueSagaCommandHandler<TSaga>`, which emits `SagaResumeRequested`. `SagaOrchestrationEffect<TSaga>` now handles this event and re-enters orchestration based on current phase.

```text
UX/Client -> ContinueSagaCommand -> ContinueSagaCommandHandler -> SagaResumeRequested event
      -> SagaOrchestrationEffect phase switch:
         Running/Failed -> execute next step
         Compensating   -> execute compensation from last completed index
         Completed/Compensated/NotStarted -> no-op
```

### Key Design Decisions

- **Manual-only trigger**: Resume is command-driven from client/UX; no reminder or scheduling behavior added.
- **State-driven re-entry**: Resume behavior uses existing saga state (`Phase`, `LastCompletedStepIndex`) to determine path.
- **Additive contracts**: New command/event are additive and preserve existing saga start/orchestration flow.

### Code Example

```csharp
ContinueSagaCommand command = new()
{
    SagaId = sagaId,
    CorrelationId = "ux-resume-123",
};

await aggregate.ExecuteAsync(command, cancellationToken);
```

## Observability

No new logging/metrics added in this slice; existing orchestration logging remains in place.

## Files Changed

### New Files

| File | Purpose |
|------|---------|
| [src/EventSourcing.Sagas.Abstractions/ContinueSagaCommand.cs](src/EventSourcing.Sagas.Abstractions/ContinueSagaCommand.cs) | Built-in manual resume command contract |
| [src/EventSourcing.Sagas.Abstractions/SagaResumeRequested.cs](src/EventSourcing.Sagas.Abstractions/SagaResumeRequested.cs) | Event contract used to trigger re-entry |
| [src/EventSourcing.Sagas/ContinueSagaCommandHandler.cs](src/EventSourcing.Sagas/ContinueSagaCommandHandler.cs) | Command handler emitting resume request event |
| [tests/EventSourcing.Sagas.L0Tests/ContinueSagaCommandHandlerTests.cs](tests/EventSourcing.Sagas.L0Tests/ContinueSagaCommandHandlerTests.cs) | Unit tests for resume command handler |

### Modified Files

| File | Change |
|------|--------|
| [src/EventSourcing.Sagas/SagaOrchestrationEffect.cs](src/EventSourcing.Sagas/SagaOrchestrationEffect.cs) | Added `SagaResumeRequested` handling and phase-based resume logic |
| [src/EventSourcing.Sagas/SagaRegistrations.cs](src/EventSourcing.Sagas/SagaRegistrations.cs) | Registered new event type and command handler |
| [tests/EventSourcing.Sagas.L0Tests/SagaOrchestrationEffectTests.cs](tests/EventSourcing.Sagas.L0Tests/SagaOrchestrationEffectTests.cs) | Added resume-event handling tests |
| [tests/EventSourcing.Sagas.L0Tests/SagaRegistrationsTests.cs](tests/EventSourcing.Sagas.L0Tests/SagaRegistrationsTests.cs) | Added registration coverage for new command/event |

### New Tests

| File | Coverage |
|------|----------|
| [tests/EventSourcing.Sagas.L0Tests/ContinueSagaCommandHandlerTests.cs](tests/EventSourcing.Sagas.L0Tests/ContinueSagaCommandHandlerTests.cs) | Validates started/not-started command behavior and emitted event |
| [tests/EventSourcing.Sagas.L0Tests/SagaOrchestrationEffectTests.cs](tests/EventSourcing.Sagas.L0Tests/SagaOrchestrationEffectTests.cs) | Validates resume behavior for failed/completed phases |
| [tests/EventSourcing.Sagas.L0Tests/SagaRegistrationsTests.cs](tests/EventSourcing.Sagas.L0Tests/SagaRegistrationsTests.cs) | Validates event type and command handler registration |

## Quality Gates

- [x] Build passes with zero warnings (targeted test project build)
- [x] All existing tests pass (targeted saga L0 tests)
- [x] New tests added for new functionality
- [ ] Documentation updated (if applicable)

## Migration Notes

No breaking changes. Existing saga start/orchestration contracts continue to work unchanged.

## Related Issues

- Related to #358