### PR TITLE
Add project reference hygiene CI gate +semver: skip

### DIFF
--- a/.github/workflows/project-reference-hygiene-gate.yml
+++ b/.github/workflows/project-reference-hygiene-gate.yml
@@ -24,6 +24,7 @@ jobs:
     name: "Fail on Unused ProjectReference (RT0002)"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - solution: mississippi.slnx


### PR DESCRIPTION
# Add project reference hygiene CI gate +semver: skip

## Business Value

This change adds an automated guardrail that prevents redundant project-to-project dependencies from accumulating in pull requests.

**Key benefits:**

1. Fails fast when unnecessary `ProjectReference` entries are introduced.
2. Reduces coupling and keeps build graphs cleaner over time.
3. Provides deterministic CI evidence (`RT0002`) instead of ad hoc local checks.

## Common Use Cases

| Domain | Use Case | Example |
|--------|----------|---------|
| Platform Engineering | Enforce dependency hygiene in CI | PR adds a transitive-only reference and gate fails with `RT0002` |
| Framework Development | Keep public packages lean | SDK project carries stale references after refactor and gate catches them |
| Team Onboarding | Standardize quality checks | New teams rely on a CI signal instead of manual `.csproj` review |

## How It Works

### Overview

The workflow runs on PRs/merge groups/manual dispatch, injects `ReferenceTrimmer` at runtime (without repository file edits), restores/builds each solution with trimming enabled, then fails if `RT0002` diagnostics are present.

```text
PR/merge_group/workflow_dispatch
  -> checkout + setup dotnet
  -> dotnet add ReferenceTrimmer to all *.csproj (runtime only)
  -> dotnet restore <solution>
  -> dotnet build <solution> -p:EnableReferenceTrimmer=true
  -> parse build log for RT0002
     -> any RT0002: fail
     -> none: pass
```

### Key Design Decisions

- **Runtime-only package injection**: Keeps repository source untouched while still enabling detection in CI.
- **Diagnostic-driven failure (`RT0002`)**: Uses the toolÔÇÖs canonical signal for unnecessary project references.
- **Matrix over both solutions**: Ensures hygiene checks apply consistently across Mississippi and Samples.

### Code Example

```csharp
// Not applicable: this change adds CI workflow automation only.
```

## Observability

Workflow emits and uploads per-solution RT0002 logs as artifacts for debugging and auditability.

| Metric/Log | Type | Description |
|------------|------|-------------|
| `rt0002-*.log` | Build log artifact | Captures trimmer output and failing RT0002 lines |

## Files Changed

### New Files

| File | Purpose |
|------|---------|
| [.github/workflows/project-reference-hygiene-gate.yml](.github/workflows/project-reference-hygiene-gate.yml) | Adds CI gate that fails when unused `ProjectReference` dependencies are detected |

### Modified Files

| File | Change |
|------|--------|
| None | Workflow-only PR |

### New Tests

| File | Coverage |
|------|----------|
| None | CI workflow behavior validated by workflow execution |

## Quality Gates

- [x] Build passes with zero warnings
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Documentation updated (if applicable)

## Migration Notes

No breaking changes. No runtime or API migration required.

```csharp
// Before
// No automated RT0002 gate in CI.

// After
// CI fails when unused ProjectReference diagnostics (RT0002) are detected.
```

## Related Issues

- None.

## Important Scope Note
This PR introduces the project-reference hygiene gate only.

- It does **not** remove unused project references.
- CI may fail when the gate finds `RT0002` issues; this is expected behavior for this PR.
- Actual reference cleanup will be done in follow-up PR(s).
