### PR TITLE
Align README SDK names and Sonar generator paths with Gateway/Runtime naming +semver: skip

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet dotnet-sonarscanner begin /k:"${{ env.SONAR_PROJECT_KEY }}" /o:"${{ env.SONAR_ORGANIZATION }}" /d:sonar.token="$SONAR_TOKEN" /d:sonar.host.url="${{ env.SONAR_HOST_URL }}" /v:${{ steps.gitversion.outputs.SemVer }} /d:"sonar.cs.vscoveragexml.reportsPaths=coverage.xml" /d:sonar.exclusions="**/*.lock.json, **/*.DotSettings,**/packages.lock.json,docs/**" /d:sonar.cpd.exclusions="**/Inlet.Client.Generators/**,**/Inlet.Server.Generators/**,**/Inlet.Silo.Generators/**" /d:sonar.issue.ignore.multicriteria=s107 /d:sonar.issue.ignore.multicriteria.s107.ruleKey=csharpsquid:S107 /d:sonar.issue.ignore.multicriteria.s107.resourceKey='**/*.cs'
+          dotnet dotnet-sonarscanner begin /k:"${{ env.SONAR_PROJECT_KEY }}" /o:"${{ env.SONAR_ORGANIZATION }}" /d:sonar.token="$SONAR_TOKEN" /d:sonar.host.url="${{ env.SONAR_HOST_URL }}" /v:${{ steps.gitversion.outputs.SemVer }} /d:"sonar.cs.vscoveragexml.reportsPaths=coverage.xml" /d:sonar.exclusions="**/*.lock.json, **/*.DotSettings,**/packages.lock.json,docs/**" /d:sonar.cpd.exclusions="**/Inlet.Client.Generators/**,**/Inlet.Gateway.Generators/**,**/Inlet.Runtime.Generators/**" /d:sonar.issue.ignore.multicriteria=s107 /d:sonar.issue.ignore.multicriteria.s107.ruleKey=csharpsquid:S107 /d:sonar.issue.ignore.multicriteria.s107.resourceKey='**/*.cs'
 
           dotnet restore ${{ env.SOLUTION_PATH }}
           dotnet build ${{ env.SOLUTION_PATH }} --configuration ${{ env.CONFIGURATION }} --no-restore --no-incremental -p:Version=${{ steps.gitversion.outputs.SemVer }}

--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ Mississippi packages are published on NuGet under the `Mississippi.*` naming pat
 Recommended entry points for application developers are the SDK packages:
 
 - `Mississippi.Sdk.Client` - client-side integration package
-- `Mississippi.Sdk.Server` - server/API integration package
-- `Mississippi.Sdk.Silo` - Orleans silo hosting integration package
+- `Mississippi.Sdk.Gateway` - gateway/API integration package
+- `Mississippi.Sdk.Runtime` - Orleans runtime hosting integration package
 
 Lower-level packages for advanced scenarios are being enabled in stages as the publish workflow is validated. The first package in this rollout is `Mississippi.Common.Abstractions`, followed by focused abstractions and runtime components such as `Mississippi.EventSourcing.*`, `Mississippi.Inlet.*`, and `Mississippi.Reservoir.*`.
 
 Example install command:
 
 ```powershell
-dotnet add package Mississippi.Sdk.Server --prerelease
+dotnet add package Mississippi.Sdk.Gateway --prerelease
 ```
 
 ### Building from Source


### PR DESCRIPTION
## Business Value

This PR updates repository metadata/config references that still used legacy `Server`/`Silo` naming, improving consistency and reducing confusion for contributors.

**Key benefits:**

1. README installation guidance now matches current SDK naming (`Gateway`/`Runtime`).
2. SonarCloud CPD exclusions now point at current generator project paths.
3. Keeps naming documentation/config aligned with the renamed host model.

## How It Works

- Updated README SDK package bullets and sample install command from `Sdk.Server`/`Sdk.Silo` to `Sdk.Gateway`/`Sdk.Runtime`.
- Updated SonarCloud scanner CPD exclusion globs from `Inlet.Server.Generators`/`Inlet.Silo.Generators` to `Inlet.Gateway.Generators`/`Inlet.Runtime.Generators`.

## Files Changed

- [README.md](README.md)
- [.github/workflows/sonar-cloud.yml](.github/workflows/sonar-cloud.yml)

## Quality Gates

- [x] Scope limited to requested two files
- [x] No code/runtime behavior changes
- [x] File-level validation reports no errors

## Migration Notes

No runtime migration required. Documentation/config reference update only.
