### PR TITLE
Document proposed builder pattern migration baseline from prototype +semver: skip

### DIFF
--- a/docs/Docusaurus/docs/proposed-patterns/builder-pattern-migration.md
+++ b/docs/Docusaurus/docs/proposed-patterns/builder-pattern-migration.md
@@ -222,4 +222,4 @@ Each extension delegates registrations into `builder.Services`, and some extensi
 
 ## See also
 
-- [Proposed Patterns](./index)
+- [Proposed Patterns](./index.md)

--- a/docs/Docusaurus/docs/proposed-patterns/index.md
+++ b/docs/Docusaurus/docs/proposed-patterns/index.md
@@ -9,4 +9,4 @@ description: Proposed architecture patterns and migration guidance under active 
 
 This section captures proposed patterns derived from validated prototypes, including the builder-pattern migration path.
 
-- [Builder Pattern Migration Matrix](./builder-pattern-migration)
+- [Builder Pattern Migration Matrix](./builder-pattern-migration.md)


### PR DESCRIPTION
## Business Value

This PR documents the proposed builder pattern from the prototype branch so the team can review and iterate on a docs-only baseline before broader implementation/migration work.

## What this includes

- Adds proposed builder migration guidance in `builder-pattern-migration.md`
- Adds/updates proposed-patterns index entry in `index.md`
- Documents root builder contracts, terminal attach semantics, validation diagnostics, runtime sub-builders, and Reservoir nested builders
- Clarifies that this is a proposed pattern based on prototype findings

## Why now

Moving to builder-first composition is a large cross-cutting change. Capturing the prototype learnings in isolated documentation gives us a stable reference point for planning and incremental adoption.

## Scope

- Docs only
- No production code changes

## Quality checks

- `npx markdownlint-cli2 "docs/Docusaurus/docs/proposed-patterns/builder-pattern-migration.md" "docs/Docusaurus/docs/proposed-patterns/index.md"` ✅