### PR TITLE
Remove XML doc code blocks from source comments +semver: skip

### DIFF
--- a/src/Aqueduct.Runtime/AqueductGrainsRegistrations.cs
+++ b/src/Aqueduct.Runtime/AqueductGrainsRegistrations.cs
@@ -23,28 +23,18 @@ public static class AqueductGrainsRegistrations
     /// <returns>The silo builder for chaining.</returns>
     /// <remarks>
     ///     <para>
-    ///         This method registers the Aqueduct grains and configures the options.
-    ///         Use the <see cref="AqueductSiloOptions" /> to configure stream providers:
+    ///         The <paramref name="configureOptions" /> callback receives an <see cref="AqueductSiloOptions" />
+    ///         instance for this silo builder.
     ///     </para>
-    ///     <code>
-    ///     // Basic setup - configure streams yourself
-    ///     siloBuilder.UseAqueduct(options =>
-    ///     {
-    ///         options.StreamProviderName = "MyStreams";
-    ///     });
-    ///
-    ///     // Development/testing with in-memory streams
-    ///     siloBuilder.UseAqueduct(options =>
-    ///     {
-    ///         options.UseMemoryStreams();
-    ///     });
-    ///
-    ///     // Production with custom stream configuration
-    ///     siloBuilder.UseAqueduct(options =>
-    ///     {
-    ///         options.UseMemoryStreams("CustomStreamProvider", "CustomPubSubStore");
-    ///     });
-    ///     </code>
+    ///     <para>
+    ///         Call <c>UseMemoryStreams()</c> or <c>UseMemoryStreams(string, string)</c> inside that
+    ///         callback for local or test setups. Otherwise, set <c>StreamProviderName</c> to the name of
+    ///         a stream provider that the host configures separately.
+    ///     </para>
+    ///     <para>
+    ///         This method copies the chosen stream and namespace values into <see cref="AqueductOptions" />
+    ///         and registers <see cref="IAqueductGrainFactory" /> for dependency injection.
+    ///     </para>
     /// </remarks>
     public static ISiloBuilder UseAqueduct(
         this ISiloBuilder siloBuilder,

--- a/src/Brooks.Runtime/BrooksRuntimeRegistrations.cs
+++ b/src/Brooks.Runtime/BrooksRuntimeRegistrations.cs
@@ -29,19 +29,14 @@ public static class BrooksRuntimeRegistrations
     /// <returns>The modified silo builder for chaining.</returns>
     /// <remarks>
     ///     <para>
-    ///         This method does NOT configure streams or storage - the host application
-    ///         is responsible for that. Use <paramref name="configureOptions" /> to tell
-    ///         Brooks which stream provider to use:
+    ///         This method does not configure Orleans streams or storage. The host application
+    ///         is responsible for registering that infrastructure separately.
     ///     </para>
-    ///     <code>
-    ///     // Host configures infrastructure
-    ///     siloBuilder.AddMemoryStreams("MyStreams");
-    ///     siloBuilder.AddMemoryGrainStorage("PubSubStore");
-    ///
-    ///     // Tell Brooks which stream provider to use
-    ///     siloBuilder.AddEventSourcing(options =&gt;
-    ///         options.OrleansStreamProviderName = "MyStreams");
-    ///     </code>
+    ///     <para>
+    ///         Use <paramref name="configureOptions" /> to align
+    ///         <c>BrookProviderOptions.OrleansStreamProviderName</c> with the stream provider name
+    ///         configured by the host. If no callback is supplied, the default option value remains in effect.
+    ///     </para>
     /// </remarks>
     public static ISiloBuilder AddEventSourcing(
         this ISiloBuilder builder,

--- a/src/DomainModeling.Gateway/AggregateControllerBase.cs
+++ b/src/DomainModeling.Gateway/AggregateControllerBase.cs
@@ -21,26 +21,13 @@ namespace Mississippi.DomainModeling.Gateway;
 ///         or add additional endpoints.
 ///     </para>
 ///     <para>
-///         Example usage:
-///         <code>
-///             [Route("api/users/{entityId}")]
-///             public class UserController : AggregateControllerBase&lt;UserAggregate&gt;
-///             {
-///                 private readonly IUserService _service;
-///                 public UserController(
-///                     IUserService service,
-///                     ILogger&lt;UserController&gt; logger) : base(logger)
-///                 {
-///                     _service = service;
-///                 }
-///                 [HttpPost("register")]
-///                 public Task&lt;ActionResult&lt;OperationResult&gt;&gt; RegisterAsync(
-///                     [FromRoute] string entityId,
-///                     [FromBody] RegisterUser command,
-///                     CancellationToken ct = default)
-///                     =&gt; ExecuteAsync(entityId, command, _service.RegisterAsync, ct);
-///             }
-///         </code>
+///         Derived controllers typically implement command-specific actions that delegate to
+///         <c>ExecuteAsync</c> so they can reuse the common logging, exception handling, and
+///         success/failure response formatting in this base type.
+///     </para>
+///     <para>
+///         Override <c>OnBeforeExecuteAsync</c> to short-circuit requests or add pre-execution checks,
+///         and override <c>OnAfterExecuteAsync</c> for post-execution concerns such as headers or metrics.
 ///     </para>
 ///     <para>
 ///         This base class provides:

--- a/src/DomainModeling.Gateway/UxProjectionControllerBase{TProjection,TDto}.cs
+++ b/src/DomainModeling.Gateway/UxProjectionControllerBase{TProjection,TDto}.cs
@@ -24,25 +24,22 @@ namespace Mississippi.DomainModeling.Gateway;
 ///         the internal projection representation from the public API contract.
 ///     </para>
 ///     <para>
-///         Example usage:
-///         <code>
-///             [Route("api/users/{entityId}")]
-///             public class UserProjectionController : UxProjectionControllerBase&lt;UserProjection, UserDto&gt;
-///             {
-///                 public UserProjectionController(
-///                     IUxProjectionGrainFactory factory,
-///                     IMapper&lt;UserProjection, UserDto&gt; mapper,
-///                     ILogger&lt;UserProjectionController&gt; logger) : base(factory, mapper, logger) { }
-///             }
-///         </code>
+///         Derived controllers are expected to apply the route template that identifies the projection
+///         resource. This base type supplies the read endpoints and maps each successful response
+///         through the injected mapper.
 ///     </para>
 ///     <para>
-///         This provides three endpoints:
+///         Override the virtual action methods only when a derived controller needs to adjust the
+///         default projection-loading behavior or response shape for a specific endpoint.
+///     </para>
+///     <para>
+///         Once a derived controller applies its route template, this base type exposes three read
+///         endpoints:
 ///         <list type="bullet">
-///             <item><c>GET /api/users/{entityId}</c> - Returns the latest projection state as a DTO.</item>
-///             <item><c>GET /api/users/{entityId}/version</c> - Returns the latest version number.</item>
+///             <item><c>GET {route}</c> - Returns the latest projection state as a DTO.</item>
+///             <item><c>GET {route}/version</c> - Returns the latest version number.</item>
 ///             <item>
-///                 <c>GET /api/users/{entityId}/at/{version}</c> - Returns the projection at a specific version as a
+///                 <c>GET {route}/at/{version}</c> - Returns the projection at a specific version as a
 ///                 DTO.
 ///             </item>
 ///         </list>

--- a/src/DomainModeling.TestHarness/Aggregates/AggregateScenario.cs
+++ b/src/DomainModeling.TestHarness/Aggregates/AggregateScenario.cs
@@ -17,16 +17,11 @@ namespace Mississippi.DomainModeling.TestHarness.Aggregates;
 /// <typeparam name="TAggregate">The aggregate type being tested.</typeparam>
 /// <remarks>
 ///     <para>
-///         Use this class to build readable test scenarios that establish state via events (Given),
-///         execute a command (When), and verify emitted events and resulting state (Then).
+///         Create a scenario via <c>CreateScenario()</c> on <see cref="AggregateTestHarness{TAggregate}" />,
+///         call <c>Given</c> to replay historical events, call <c>When</c> to execute the command under
+///         test, and finish with the <c>Then*</c> members to assert emitted events, failures, or resulting
+///         state.
 ///     </para>
-///     <code>
-///         harness.CreateScenario()
-///             .Given(new AccountOpened { HolderName = "John", InitialDeposit = 100m })
-///             .When(new DepositFunds { Amount = 50m })
-///             .ThenEmits&lt;FundsDeposited&gt;(e =&gt; e.Amount.Should().Be(50m))
-///             .ThenState(s =&gt; s.Balance.Should().Be(150m));
-///     </code>
 /// </remarks>
 public sealed class AggregateScenario<TAggregate>
     where TAggregate : new()

--- a/src/DomainModeling.TestHarness/Aggregates/AggregateTestHarness.cs
+++ b/src/DomainModeling.TestHarness/Aggregates/AggregateTestHarness.cs
@@ -35,22 +35,10 @@ namespace Mississippi.DomainModeling.TestHarness.Aggregates;
 ///         </item>
 ///     </list>
 ///     <para>
-///         <strong>Example:</strong>
-///     </para>
-///     <code>
-///         CommandHandlerTestExtensions.ForAggregate&lt;BankAccountAggregate&gt;()
-///             .WithHandler&lt;OpenAccountHandler&gt;()
-///             .WithHandler&lt;DepositFundsHandler&gt;()
-///             .WithReducer&lt;AccountOpenedReducer&gt;()
-///             .WithReducer&lt;FundsDepositedReducer&gt;()
-///             .CreateScenario()
-///             .Given(new AccountOpened { HolderName = "Test", InitialDeposit = 100m })
-///             .When(new DepositFunds { Amount = 50m })
-///             .ThenEmits&lt;FundsDeposited&gt;(e =&gt; e.Amount.Should().Be(50m))
-///             .ThenState(s =&gt; s.Balance.Should().Be(150m));
-///     </code>
-///     <para>
 ///         <strong>Unified Testing Approach:</strong>
+///         Register the handlers and reducers your aggregate needs, then call <c>CreateScenario()</c>
+///         to chain <c>Given</c>, <c>When</c>, and <c>Then</c> assertions. Given events are replayed
+///         through the registered reducers before <c>When</c> executes the matching command handler.
 ///         This harness shares design patterns with
 ///         <see cref="ReducerTestHarness{TProjection}" />,
 ///         enabling consistent testing for both projections and aggregates.

--- a/src/DomainModeling.TestHarness/Projections/ProjectionScenario.cs
+++ b/src/DomainModeling.TestHarness/Projections/ProjectionScenario.cs
@@ -16,15 +16,10 @@ namespace Mississippi.DomainModeling.TestHarness.Projections;
 /// <typeparam name="TProjection">The projection type being tested.</typeparam>
 /// <remarks>
 ///     <para>
-///         Use this class to build readable test scenarios that establish state via events (Given),
-///         apply a new event (When), and verify the resulting projection (Then).
+///         Create a scenario via <c>CreateScenario()</c> on <see cref="ReducerTestHarness{TProjection}" />,
+///         use <c>Given</c> to replay historical events into the starting state, use <c>When</c> for the
+///         event under test, and finish with the <c>Then*</c> members to assert the resulting projection.
 ///     </para>
-///     <code>
-///         harness.CreateScenario()
-///             .Given(new AccountOpened { HolderName = "John", InitialDeposit = 100m })
-///             .When(new FundsDeposited { Amount = 50m })
-///             .ThenAssert(p =&gt; p.Balance.Should().Be(150m));
-///     </code>
 /// </remarks>
 public sealed class ProjectionScenario<TProjection>
     where TProjection : new()

--- a/src/DomainModeling.TestHarness/Projections/ReducerTestHarness.cs
+++ b/src/DomainModeling.TestHarness/Projections/ReducerTestHarness.cs
@@ -13,37 +13,19 @@ namespace Mississippi.DomainModeling.TestHarness.Projections;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         This harness enables both single-reducer unit testing and multi-reducer scenario testing
+///         This harness enables both single-reducer checks and multi-reducer scenario testing
 ///         using a fluent Given/When/Then style API. It is designed for L0 (pure unit) tests
 ///         that remain in-memory without external dependencies.
 ///     </para>
 ///     <para>
-///         <strong>Single Reducer Testing (L0):</strong>
-///         Use the extension methods directly on reducers for isolated unit tests.
+///         For a single reducer, prefer the direct extension methods on <see cref="ReducerTestExtensions" />
+///         when you want to apply one event and assert the result immediately.
 ///     </para>
-///     <code>
-///         // Quick apply and assert
-///         var result = reducer.Apply(initialState, eventData);
-///         result.Balance.Should().Be(expected);
-///         // Or use ShouldProduce for expected output assertions
-///         reducer.ShouldProduce(initialState, eventData, expectedProjection);
-///     </code>
 ///     <para>
-///         <strong>Multi-Reducer Scenario Testing (L0):</strong>
-///         Use the harness to compose multiple reducers and test event replay scenarios.
+///         Use this harness when a projection depends on multiple reducers or when you want to replay
+///         event sequences. Register the participating reducers with the <c>WithReducer</c> overloads,
+///         then use <c>ApplyEvent</c>, <c>ApplyEvents</c>, or <c>CreateScenario()</c> as needed.
 ///     </para>
-///     <code>
-///         // Create a harness with all reducers for a projection
-///         var harness = ReducerTestExtensions.ForProjection&lt;BankAccountBalanceProjection&gt;()
-///             .WithReducer&lt;AccountOpenedBalanceReducer&gt;()
-///             .WithReducer&lt;FundsDepositedBalanceReducer&gt;()
-///             .WithReducer&lt;FundsWithdrawnBalanceReducer&gt;();
-///         // Run a scenario with Given/When/Then
-///         harness.CreateScenario()
-///             .Given(new AccountOpened { HolderName = "John", InitialDeposit = 100m })
-///             .When(new FundsDeposited { Amount = 50m })
-///             .ThenAssert(p =&gt; p.Balance.Should().Be(150m));
-///     </code>
 /// </remarks>
 /// <typeparam name="TProjection">The projection type being tested. Must have a parameterless constructor.</typeparam>
 /// <seealso cref="ProjectionScenario{TProjection}" />

--- a/src/Inlet.Abstractions/ProjectionPathAttribute.cs
+++ b/src/Inlet.Abstractions/ProjectionPathAttribute.cs
@@ -35,15 +35,9 @@ namespace Mississippi.Inlet.Abstractions;
 ///         </list>
 ///     </para>
 ///     <para>
-///         Example usage:
-///         <code>
-///             // Server-side projection (in Domain project):
-///             [ProjectionPath("chat/channels")]
-///             public sealed record ChannelMessagesProjection { ... }
-///             // Client-side DTO (in Contracts project, WASM-safe):
-///             [ProjectionPath("chat/channels")]
-///             public sealed record ChannelMessagesDto { ... }
-///         </code>
+///         Apply the same projection path to the server-side projection type, any client DTO,
+///         and any shared contract that represents the same subscription surface so routes and
+///         subscriptions use a consistent address.
 ///     </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]


### PR DESCRIPTION
## Business Value

This PR removes stale-prone XML doc code samples from source comments while keeping accurate IntelliSense guidance in place. That keeps the repository compliant with the XML documentation rule, reduces maintenance burden, and steers developers toward living code and tests instead of examples that can silently drift.

The issue body enumerated 7 additional files and separately noted earlier related fixes to `AggregateControllerBase.cs` and `AggregateScenario.cs`. Repository verification for this clean branch therefore established the full scope as **9 relevant source files containing 10 XML `<code>` blocks**, and this PR fixes that full verified scope.

**Key benefits:**

1. Removes the remaining verified XML `<code>` blocks from source comments.
2. Preserves useful guidance as concise prose that matches the implementation.
3. Finishes the full verified source-comment cleanup without changing runtime behavior.

## Common Use Cases

| Domain | Use Case | Example |
|--------|----------|---------|
| Test harness consumers | Understand the supported scenario flow without stale inline samples | `AggregateTestHarness`, `AggregateScenario`, `ReducerTestHarness`, and `ProjectionScenario` now describe the fluent `Given`/`When`/`Then` flow in prose only. |
| Gateway/controller authors | Understand inheritance and endpoint extension points from accurate remarks | `AggregateControllerBase` and `UxProjectionControllerBase<TProjection, TDto>` now document hooks and routing responsibility without embedded code snippets. |
| Host configuration authors | Understand setup invariants without copy-paste drift | `UseAqueduct(...)`, `AddEventSourcing(...)`, and `ProjectionPathAttribute` now describe stream-provider and path conventions as truthful prose. |

## How It Works

### Overview

This is a comment-only cleanup. Each affected XML `<code>` block was removed, and each remark block was reduced to concise prose that states only what the implementation actually guarantees.

```text
Issue #425 listed 7 additional files
and separately referenced 2 related source-comment fixes
                ↓
Verified branch scope = 9 relevant source files / 10 XML <code> blocks
                ↓
Remove XML code blocks and keep only truthful prose
                ↓
Validate on the clean branch with go.ps1 + explicit mutation log
```

### Key Design Decisions

- **Fix the full verified scope**: the clean branch includes the 7 files listed in the issue body plus the 2 related source files already referenced in the issue notes, so the PR closes the full 9-file / 10-block scope.
- **Keep the diff comment-only**: no runtime behavior, public API signatures, routing, DI, storage, or serialization behavior changed.
- **Preserve guidance without examples**: short prose remains where it materially helps readers understand setup order, configuration invariants, and controller/test-harness contracts.

## Files Changed

### Modified Files

| File | Change |
|------|--------|
| `src/DomainModeling.TestHarness/Aggregates/AggregateTestHarness.cs` | Replaced XML sample code with concise prose that preserves the supported fluent setup and scenario flow. |
| `src/DomainModeling.TestHarness/Aggregates/AggregateScenario.cs` | Replaced XML sample code with prose describing the supported `Given` / `When` / `Then*` flow. |
| `src/DomainModeling.TestHarness/Projections/ReducerTestHarness.cs` | Replaced XML sample code with prose covering single-reducer vs. multi-reducer setup and scenario creation. |
| `src/DomainModeling.TestHarness/Projections/ProjectionScenario.cs` | Replaced XML sample code with prose describing replay, apply, and assertion flow. |
| `src/Aqueduct.Runtime/AqueductGrainsRegistrations.cs` | Replaced XML sample code with prose describing `AqueductSiloOptions` and stream-provider configuration invariants. |
| `src/DomainModeling.Gateway/UxProjectionControllerBase{TProjection,TDto}.cs` | Replaced XML sample code with prose describing derived-controller routing responsibility and overridable read endpoints. |
| `src/DomainModeling.Gateway/AggregateControllerBase.cs` | Replaced XML sample code with prose describing `ExecuteAsync(...)` delegation and supported pre/post hooks. |
| `src/Brooks.Runtime/BrooksRuntimeRegistrations.cs` | Replaced XML sample code with prose describing how `BrookProviderOptions` must align with host stream/storage setup. |
| `src/Inlet.Abstractions/ProjectionPathAttribute.cs` | Replaced XML sample code with prose describing the shared projection path convention. |

No product docs pages changed because this PR is limited to source XML comments only.

## Quality Gates

- [x] Clean-branch `go.ps1` succeeded in `.scratchpad/worktrees/issue-425-remove-xml-doc-code-blocks/.scratchpad/go-issue-425.log`, including successful Mississippi and Samples build/test/cleanup and a final `Build succeeded.` / `0 Warning(s)` / `0 Error(s)` / `=== PIPELINE COMPLETED SUCCESSFULLY ===`
- [x] Explicit mutation validation succeeded in `.scratchpad/worktrees/issue-425-remove-xml-doc-code-blocks/.scratchpad/mutation-issue-425.log`, ending with `SUCCESS: Mutation testing completed with acceptable scores` and `Mutation score meets project standards`
- [x] Verified branch diff is bounded to 9 source files and remains comment-only
- [x] No product docs update required because the scope is source XML comments only

## Migration Notes

No breaking changes. No migration is required.

## Related Issues

- Fixes #425