### PR TITLE
Add Tributary Azure Blob snapshot storage provider (vfe agent) +semver: feature

### DIFF
--- a/docs/Docusaurus/docs/tributary/storage-providers/blob-storage.md
+++ b/docs/Docusaurus/docs/tributary/storage-providers/blob-storage.md
@@ -1,0 +1,118 @@
+---
+id: tributary-storage-blob
+title: "Tributary: Azure Blob Provider"
+sidebar_label: Azure Blob
+sidebar_position: 2
+description: Azure Blob Storage snapshot provider reference for Tributary.
+---
+
+# Tributary: Azure Blob Provider
+
+## Overview
+
+The Azure Blob snapshot provider stores each snapshot as one JSON document Blob in a dedicated container. It implements `ISnapshotStorageProvider` and reports `Format` as `azure-blob`.
+
+## Packages
+
+- `Mississippi.Tributary.Runtime.Storage.Blobs`
+- `Mississippi.Tributary.Runtime.Storage.Abstractions`
+
+## Registration
+
+Register the provider with `AddBlobSnapshotStorageProvider()` on `IServiceCollection`.
+
+The provider expects a keyed `BlobServiceClient` whose default key is `SnapshotBlobDefaults.BlobServiceClientServiceKey` (`mississippi-blob-snapshots`). Hosts can forward any deployment-specific key to that provider-owned key.
+
+## Configuration Options
+
+Configuration is provided through `SnapshotBlobStorageOptions`:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BlobServiceClientServiceKey` | `SnapshotBlobDefaults.BlobServiceClientServiceKey` | Keyed service key for resolving `BlobServiceClient` |
+| `ContainerName` | `SnapshotBlobDefaults.ContainerName` | Blob container used for snapshots |
+| `EnableCompression` | `false` | Enables gzip compression for stored payload bytes |
+| `MaximumSnapshotPayloadSizeBytes` | `SnapshotBlobDefaults.DefaultMaximumSnapshotPayloadSizeBytes` | Maximum uncompressed snapshot payload size accepted on read or write |
+
+The default maximum uncompressed payload size is 128 MiB. Increase it only when a domain has deliberately large snapshots; the guard is checked before gzip decompression so malformed or unexpected Blob content cannot expand without a configured bound.
+
+For production Azure deployments, prefer registering your own keyed `BlobServiceClient` with managed identity or another credential flow and then calling `AddBlobSnapshotStorageProvider()`. The connection-string overload is useful for local development, tests, and simple hosts.
+
+## Container Initialization
+
+The provider registers `SnapshotBlobContainerInitializer` as a hosted service. On host startup it calls `CreateContainerIfNotExistsAsync` for the configured private container. Registration remains synchronous; the container creation happens asynchronously after the host starts.
+
+## Blob Naming
+
+Each snapshot uses this durable Blob path format:
+
+`v1/streams/{SHA256HEX(SnapshotStreamKey.ToString())}/versions/{version:D20}.json`
+
+Notes:
+
+- The provider hashes `SnapshotStreamKey.ToString()` with SHA-256 and uses the uppercase hexadecimal digest.
+- Raw `SnapshotKey.ToString()` and raw stream components are not used as Blob names.
+- Version names are zero-padded to 20 digits so lexical ordering matches numeric ordering.
+- `SnapshotStreamKey.ToString()` includes `ReducersHash`; changing the reducer hash creates a new Blob prefix. Delete or prune old-hash snapshots after a reducer migration if they are no longer needed.
+
+## JSON Document Schema
+
+The Blob body is JSON with these fields:
+
+| Field | Meaning |
+|-------|---------|
+| `schemaVersion` | Document schema version. Current value: `1` |
+| `brookName` | `SnapshotStreamKey.BrookName` |
+| `snapshotStorageName` | `SnapshotStreamKey.SnapshotStorageName` |
+| `entityId` | `SnapshotStreamKey.EntityId` |
+| `reducersHash` | `SnapshotStreamKey.ReducersHash` and returned `SnapshotEnvelope.ReducerHash` |
+| `version` | Snapshot version |
+| `dataContentType` | `SnapshotEnvelope.DataContentType` |
+| `dataSizeBytes` | Uncompressed payload size |
+| `compression` | `none` or `gzip` |
+| `storedSizeBytes` | Stored byte count before Base64 encoding |
+| `data` | Base64-encoded stored bytes |
+
+The Blob HTTP content type is `application/json`. The provider does not use Azure HTTP `Content-Encoding`.
+
+## Compression Behavior
+
+Compression is optional.
+
+- When `EnableCompression` is `false`, the provider stores the payload bytes unchanged and writes `compression: none`.
+- When `EnableCompression` is `true`, the provider gzip-compresses the payload bytes before Base64 encoding and writes `compression: gzip`.
+- `dataSizeBytes` always records the uncompressed payload size.
+- `storedSizeBytes` records the stored byte count before Base64 encoding.
+
+## Read Validation
+
+Reads fail closed when stored data does not match the requested snapshot or the stored metadata is invalid. The provider validates:
+
+- `schemaVersion`
+- `brookName`
+- `snapshotStorageName`
+- `entityId`
+- `reducersHash`
+- `version`
+- Base64 payload integrity
+- supported `compression` values
+- `storedSizeBytes`
+- `dataSizeBytes`
+
+When a read succeeds, the returned `SnapshotEnvelope` preserves `ReducerHash`.
+
+## Diagnostics
+
+The provider emits metrics through the `Mississippi.Storage.Blob.Snapshots` meter.
+
+## Spring Sample
+
+`samples/Spring/Spring.Runtime/Program.cs` forwards the Aspire `blobs` resource to `SnapshotBlobDefaults.BlobServiceClientServiceKey` and registers `AddBlobSnapshotStorageProvider(options => options.EnableCompression = true);`.
+
+Brooks event storage remains on Cosmos DB.
+
+## Next Steps
+
+- [Storage Providers Overview](index.md)
+- [Tributary Operations](../operations/operations.md)
+- [Tributary Troubleshooting](../troubleshooting/troubleshooting.md)

--- a/docs/Docusaurus/docs/tributary/storage-providers/index.md
+++ b/docs/Docusaurus/docs/tributary/storage-providers/index.md
@@ -8,13 +8,11 @@ description: Storage provider model for snapshot persistence in Mississippi.
 
 # Tributary Storage Providers
 
-:::warning
-This section contains placeholder content. Detailed guidance for each provider is still being written.
-:::
-
 ## Overview
 
 Tributary uses a pluggable storage-provider model for snapshot persistence. Each provider implements the `ISnapshotStorageProvider` interface, which combines read and write operations and identifies itself with a `Format` string.
+
+The Spring sample now uses the Azure Blob provider for snapshots while Brooks event streams remain on Cosmos DB.
 
 ## Provider Model
 
@@ -30,11 +28,13 @@ Implementations are registered through extension methods on `IServiceCollection`
 
 | Provider | Package | Status |
 |----------|---------|--------|
+| [Azure Blob Storage](blob-storage.md) | `Mississippi.Tributary.Runtime.Storage.Blobs` | Available |
 | [Cosmos DB](cosmos.md) | `Mississippi.Tributary.Runtime.Storage.Cosmos` | Available |
 
 ## Learn More
 
 - [Tributary Overview](../index.md) - Return to the Tributary section landing page
+- [Azure Blob Storage Provider](blob-storage.md)
 - [Cosmos DB Provider](cosmos.md)
 - [Tributary Concepts](../concepts/concepts.md)
 - [Tributary Reference](../reference/reference.md)

--- a/mississippi.slnx
+++ b/mississippi.slnx
@@ -28,6 +28,7 @@
     <Project Path="src\Brooks.Serialization.Json\Brooks.Serialization.Json.csproj" />
   </Folder>
   <Folder Name="/Framework/EventSourcing/Snapshots/">
+    <Project Path="src\Tributary.Runtime.Storage.Blobs\Tributary.Runtime.Storage.Blobs.csproj" />
     <Project Path="src\Tributary.Runtime.Storage.Cosmos\Tributary.Runtime.Storage.Cosmos.csproj" />
   </Folder>
   <Folder Name="/Framework/EventSourcing/Tributary/">
@@ -105,6 +106,7 @@
     <Project Path="tests\Brooks.Serialization.Json.L0Tests\Brooks.Serialization.Json.L0Tests.csproj" />
   </Folder>
   <Folder Name="/Tests/EventSourcing/Snapshots/">
+    <Project Path="tests\Tributary.Runtime.Storage.Blobs.L0Tests\Tributary.Runtime.Storage.Blobs.L0Tests.csproj" />
     <Project Path="tests\Tributary.Runtime.Storage.Cosmos.L0Tests\Tributary.Runtime.Storage.Cosmos.L0Tests.csproj" />
   </Folder>
   <Folder Name="/Tests/EventSourcing/Tributary/">

--- a/samples/Spring/Spring.AppHost/Program.cs
+++ b/samples/Spring/Spring.AppHost/Program.cs
@@ -27,7 +27,7 @@ IResourceBuilder<AzureTableStorageResource> reminderTable = storage.AddTables("r
 // Add Azure Blob Storage for Orleans grain state
 IResourceBuilder<AzureBlobStorageResource> grainState = storage.AddBlobs("grainstate");
 
-// Add Cosmos DB using PREVIEW emulator for event sourcing storage (Brooks + Snapshots)
+// Add Cosmos DB using PREVIEW emulator for Brooks event-stream storage
 IResourceBuilder<AzureCosmosDBResource> cosmos = builder.AddAzureCosmosDB("cosmos")
     .RunAsPreviewEmulator(emulator =>
     {
@@ -47,7 +47,7 @@ OrleansService orleans = builder.AddOrleans("default")
     .WithMemoryStreaming("StreamProvider");
 
 // Add MississippiSamples.Spring.Runtime - business runtime host (runs in an Orleans silo)
-// WithReference cosmos/blobs for event sourcing storage (Brooks + Snapshots)
+// WithReference cosmos for Brooks event storage and blobs for locking plus Blob snapshots
 // WithHealthCheck ensures the runtime host is fully ready before dependents start
 IResourceBuilder<ProjectResource> springRuntime = builder.AddProject<Spring_Runtime>("spring-runtime")
     .WithReference(orleans)

--- a/samples/Spring/Spring.Runtime/Program.cs
+++ b/samples/Spring/Spring.Runtime/Program.cs
@@ -12,7 +12,7 @@ using Mississippi.Brooks.Runtime.Storage.Cosmos;
 using Mississippi.Brooks.Serialization.Json;
 using Mississippi.Inlet.Runtime;
 using Mississippi.Tributary.Runtime;
-using Mississippi.Tributary.Runtime.Storage.Cosmos;
+using Mississippi.Tributary.Runtime.Storage.Blobs;
 
 using MississippiSamples.Spring.Domain.Projections.BankAccountBalance;
 using MississippiSamples.Spring.Domain.Services;
@@ -59,8 +59,8 @@ builder.Services.AddOpenTelemetry()
         .AddMeter("Mississippi.Brooks.Runtime")
         .AddMeter("Mississippi.DomainModeling.Runtime")
         .AddMeter("Mississippi.Tributary.Runtime")
+        .AddMeter("Mississippi.Storage.Blob.Snapshots")
         .AddMeter("Mississippi.Storage.Cosmos")
-        .AddMeter("Mississippi.Storage.Snapshots")
         .AddMeter("Mississippi.Storage.Locking")
 
         // Orleans meters
@@ -75,7 +75,7 @@ builder.AddKeyedAzureTableServiceClient("clustering");
 builder.AddKeyedAzureTableServiceClient("reminders");
 builder.AddKeyedAzureBlobServiceClient("grainstate");
 
-// Add Aspire-managed Cosmos client for event sourcing storage (Brooks + Snapshots)
+// Add Aspire-managed Cosmos client for Brooks event storage
 // Gateway mode required for Aspire Cosmos emulator compatibility
 builder.AddAzureCosmosClient(
     "cosmos",
@@ -85,7 +85,7 @@ builder.AddAzureCosmosClient(
         options.LimitToEndpoint = true;
     });
 
-// Add Blob client for distributed locking (Brooks)
+// Add Blob client for distributed locking (Brooks) and snapshot storage (Tributary)
 builder.AddKeyedAzureBlobServiceClient("blobs");
 
 // Forward the Aspire-registered blob client to the Brooks key used by BlobDistributedLockManager
@@ -96,8 +96,15 @@ builder.Services.AddKeyedSingleton(
         _
     ) => sp.GetRequiredKeyedService<BlobServiceClient>("blobs"));
 
-// Forward the Aspire-registered Cosmos client to a shared Mississippi keyed service key
-// Both Brooks and Snapshots use the same Cosmos account but different containers
+// Forward the Aspire-registered blob client to the Tributary snapshot Blob provider key
+builder.Services.AddKeyedSingleton(
+    SnapshotBlobDefaults.BlobServiceClientServiceKey,
+    (
+        sp,
+        _
+    ) => sp.GetRequiredKeyedService<BlobServiceClient>("blobs"));
+
+// Forward the Aspire-registered Cosmos client to a shared Mississippi keyed service key for Brooks event storage
 const string sharedCosmosKey = "spring-cosmos";
 builder.Services.AddKeyedSingleton(
     sharedCosmosKey,
@@ -125,14 +132,8 @@ builder.Services.AddCosmosBrookStorageProvider(options =>
     options.MaxEventsPerBatch = 50;
 });
 
-// Configure Cosmos storage for Snapshots
-builder.Services.AddCosmosSnapshotStorageProvider(options =>
-{
-    options.CosmosClientServiceKey = sharedCosmosKey;
-    options.DatabaseId = "spring-db";
-    options.ContainerId = "snapshots";
-    options.QueryBatchSize = 100;
-});
+// Configure Blob storage for Snapshots
+builder.Services.AddBlobSnapshotStorageProvider(options => { options.EnableCompression = true; });
 
 // Configure Orleans silo - Aspire injects clustering config via environment variables
 builder.UseOrleans(siloBuilder =>

--- a/samples/Spring/Spring.Runtime/Spring.Runtime.csproj
+++ b/samples/Spring/Spring.Runtime/Spring.Runtime.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Spring.Domain\Spring.Domain.csproj" />
     <ProjectReference Include="..\..\..\src\Sdk.Runtime\Sdk.Runtime.csproj" />
+    <ProjectReference Include="..\..\..\src\Tributary.Runtime.Storage.Blobs\Tributary.Runtime.Storage.Blobs.csproj" />
     <ProjectReference Include="..\..\..\src\Inlet.Generators.Core\Inlet.Generators.Core.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     <ProjectReference Include="..\..\..\src\Inlet.Runtime.Generators\Inlet.Runtime.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/Spring/Spring.Runtime/packages.lock.json
+++ b/samples/Spring/Spring.Runtime/packages.lock.json
@@ -694,6 +694,15 @@
           "Mississippi.Tributary.Abstractions": "[1.0.0, )"
         }
       },
+      "Mississippi.Tributary.Runtime.Storage.Blobs": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Storage.Blobs": "[12.28.0, )",
+          "Mississippi.Common.Abstractions": "[1.0.0, )",
+          "Mississippi.Tributary.Abstractions": "[1.0.0, )",
+          "Mississippi.Tributary.Runtime.Storage.Abstractions": "[1.0.0, )"
+        }
+      },
       "Mississippi.Tributary.Runtime.Storage.Cosmos": {
         "type": "Project",
         "dependencies": {

--- a/src/Tributary.Runtime.Storage.Blobs/Diagnostics/SnapshotBlobStorageMetrics.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Diagnostics/SnapshotBlobStorageMetrics.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Diagnostics;
+
+/// <summary>
+///     OpenTelemetry metrics for Blob snapshot storage operations.
+/// </summary>
+internal static class SnapshotBlobStorageMetrics
+{
+    /// <summary>
+    ///     The meter name for Blob snapshot storage metrics.
+    /// </summary>
+    internal const string MeterName = "Mississippi.Storage.Blob.Snapshots";
+
+    private const string SnapshotTypeTag = "snapshot.type";
+
+    private static readonly Meter SnapshotStorageMeter = new(MeterName);
+
+    private static readonly Counter<long> DeleteCount = SnapshotStorageMeter.CreateCounter<long>(
+        "blob.snapshot.delete.count",
+        "deletes",
+        "Number of Blob snapshot deletions.");
+
+    private static readonly Counter<long> PruneCount = SnapshotStorageMeter.CreateCounter<long>(
+        "blob.snapshot.prune.count",
+        "prunes",
+        "Number of Blob snapshot prune deletions.");
+
+    private static readonly Counter<long> ReadCount = SnapshotStorageMeter.CreateCounter<long>(
+        "blob.snapshot.read.count",
+        "reads",
+        "Number of Blob snapshot reads.");
+
+    private static readonly Histogram<double> ReadDuration = SnapshotStorageMeter.CreateHistogram<double>(
+        "blob.snapshot.read.duration",
+        "ms",
+        "Blob snapshot read duration.");
+
+    private static readonly Histogram<long> SnapshotSize = SnapshotStorageMeter.CreateHistogram<long>(
+        "blob.snapshot.size",
+        "bytes",
+        "Blob snapshot payload size in bytes.");
+
+    private static readonly Counter<long> WriteCount = SnapshotStorageMeter.CreateCounter<long>(
+        "blob.snapshot.write.count",
+        "writes",
+        "Number of Blob snapshot writes.");
+
+    private static readonly Histogram<double> WriteDuration = SnapshotStorageMeter.CreateHistogram<double>(
+        "blob.snapshot.write.duration",
+        "ms",
+        "Blob snapshot write duration.");
+
+    /// <summary>
+    ///     Records a snapshot deletion.
+    /// </summary>
+    /// <param name="snapshotType">The snapshot type name.</param>
+    internal static void RecordDelete(
+        string snapshotType
+    )
+    {
+        TagList tags = default;
+        tags.Add(SnapshotTypeTag, snapshotType);
+        DeleteCount.Add(1, tags);
+    }
+
+    /// <summary>
+    ///     Records a prune operation when snapshots were deleted.
+    /// </summary>
+    /// <param name="snapshotType">The snapshot type name.</param>
+    /// <param name="prunedCount">The number of deleted snapshots.</param>
+    internal static void RecordPrune(
+        string snapshotType,
+        int prunedCount
+    )
+    {
+        if (prunedCount <= 0)
+        {
+            return;
+        }
+
+        TagList tags = default;
+        tags.Add(SnapshotTypeTag, snapshotType);
+        PruneCount.Add(prunedCount, tags);
+    }
+
+    /// <summary>
+    ///     Records a snapshot read.
+    /// </summary>
+    /// <param name="snapshotType">The snapshot type name.</param>
+    /// <param name="durationMs">The duration in milliseconds.</param>
+    /// <param name="found">Whether the snapshot was found.</param>
+    internal static void RecordRead(
+        string snapshotType,
+        double durationMs,
+        bool found
+    )
+    {
+        TagList tags = default;
+        tags.Add(SnapshotTypeTag, snapshotType);
+        tags.Add("result", found ? "found" : "not_found");
+        ReadCount.Add(1, tags);
+        ReadDuration.Record(durationMs, tags);
+    }
+
+    /// <summary>
+    ///     Records a snapshot write.
+    /// </summary>
+    /// <param name="snapshotType">The snapshot type name.</param>
+    /// <param name="durationMs">The duration in milliseconds.</param>
+    /// <param name="success">Whether the write succeeded.</param>
+    /// <param name="sizeBytes">The uncompressed payload size in bytes.</param>
+    internal static void RecordWrite(
+        string snapshotType,
+        double durationMs,
+        bool success,
+        long sizeBytes = 0
+    )
+    {
+        TagList tags = default;
+        tags.Add(SnapshotTypeTag, snapshotType);
+        tags.Add("result", success ? "success" : "failure");
+        WriteCount.Add(1, tags);
+        WriteDuration.Record(durationMs, tags);
+        if (sizeBytes > 0)
+        {
+            TagList sizeTags = default;
+            sizeTags.Add(SnapshotTypeTag, snapshotType);
+            SnapshotSize.Record(sizeBytes, sizeTags);
+        }
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/ISnapshotBlobOperations.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/ISnapshotBlobOperations.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Abstracts Azure Blob SDK operations for snapshot storage.
+/// </summary>
+internal interface ISnapshotBlobOperations
+{
+    /// <summary>
+    ///     Creates the configured snapshot container when it does not already exist.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task CreateContainerIfNotExistsAsync(
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Deletes a Blob when it exists.
+    /// </summary>
+    /// <param name="blobName">The Blob name to delete.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns><c>true</c> when the Blob existed and was deleted; otherwise <c>false</c>.</returns>
+    Task<bool> DeleteIfExistsAsync(
+        string blobName,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Downloads a snapshot document Blob.
+    /// </summary>
+    /// <param name="blobName">The Blob name to download.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The Blob content when found; otherwise <c>null</c>.</returns>
+    Task<BinaryData?> DownloadAsync(
+        string blobName,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Lists Blob names under a stream-scoped prefix.
+    /// </summary>
+    /// <param name="prefix">The Blob prefix to list.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>An asynchronous sequence of Blob names.</returns>
+    IAsyncEnumerable<string> ListBlobNamesAsync(
+        string prefix,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Uploads a snapshot document Blob.
+    /// </summary>
+    /// <param name="blobName">The destination Blob name.</param>
+    /// <param name="document">The serialized JSON document to upload.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task UploadAsync(
+        string blobName,
+        BinaryData document,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Tributary.Runtime.Storage.Blobs/ISnapshotBlobRepository.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/ISnapshotBlobRepository.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Mississippi.Tributary.Abstractions;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Provides Blob-backed snapshot persistence semantics behind the provider facade.
+/// </summary>
+internal interface ISnapshotBlobRepository
+{
+    /// <summary>
+    ///     Deletes all snapshots for a stream.
+    /// </summary>
+    /// <param name="streamKey">The stream key identifying the snapshot stream.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DeleteAllAsync(
+        SnapshotStreamKey streamKey,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Deletes a specific snapshot version.
+    /// </summary>
+    /// <param name="snapshotKey">The snapshot key identifying the snapshot version.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DeleteAsync(
+        SnapshotKey snapshotKey,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Prunes snapshots for a stream.
+    /// </summary>
+    /// <param name="streamKey">The stream key identifying the snapshot stream.</param>
+    /// <param name="retainModuli">The retention moduli.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The number of deleted snapshots.</returns>
+    Task<int> PruneAsync(
+        SnapshotStreamKey streamKey,
+        IReadOnlyCollection<int> retainModuli,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Reads a snapshot version from Blob storage.
+    /// </summary>
+    /// <param name="snapshotKey">The snapshot key identifying the snapshot version.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The snapshot envelope when found; otherwise <c>null</c>.</returns>
+    Task<SnapshotEnvelope?> ReadAsync(
+        SnapshotKey snapshotKey,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    ///     Writes a snapshot version to Blob storage.
+    /// </summary>
+    /// <param name="snapshotKey">The snapshot key identifying the snapshot version.</param>
+    /// <param name="snapshot">The snapshot envelope to persist.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task WriteAsync(
+        SnapshotKey snapshotKey,
+        SnapshotEnvelope snapshot,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobContainerInitializer.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobContainerInitializer.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Ensures the snapshot Blob container exists when the host starts.
+/// </summary>
+internal sealed class SnapshotBlobContainerInitializer : IHostedService
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="SnapshotBlobContainerInitializer" /> class.
+    /// </summary>
+    /// <param name="operations">The Blob operations abstraction.</param>
+    /// <param name="logger">The logger for diagnostic output.</param>
+    public SnapshotBlobContainerInitializer(
+        ISnapshotBlobOperations operations,
+        ILogger<SnapshotBlobContainerInitializer> logger
+    )
+    {
+        Operations = operations ?? throw new ArgumentNullException(nameof(operations));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    private ILogger<SnapshotBlobContainerInitializer> Logger { get; }
+
+    private ISnapshotBlobOperations Operations { get; }
+
+    /// <inheritdoc />
+    public async Task StartAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        Logger.EnsuringSnapshotContainer();
+        await Operations.CreateContainerIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
+        Logger.SnapshotContainerReady();
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(
+        CancellationToken cancellationToken
+    ) =>
+        Task.CompletedTask;
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobContainerInitializerLoggerExtensions.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobContainerInitializerLoggerExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     High-performance logging extensions for <see cref="SnapshotBlobContainerInitializer" />.
+/// </summary>
+internal static partial class SnapshotBlobContainerInitializerLoggerExtensions
+{
+    /// <summary>
+    ///     Logs when the snapshot container check begins.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Ensuring the Blob snapshot container exists.")]
+    public static partial void EnsuringSnapshotContainer(
+        this ILogger logger
+    );
+
+    /// <summary>
+    ///     Logs when the snapshot container is ready.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "The Blob snapshot container is ready.")]
+    public static partial void SnapshotContainerReady(
+        this ILogger logger
+    );
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobDefaults.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobDefaults.cs
@@ -1,0 +1,27 @@
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Default constants for Blob snapshot storage configuration and keyed service registrations.
+/// </summary>
+public static class SnapshotBlobDefaults
+{
+    /// <summary>
+    ///     The keyed DI service key for the Blob container client used by the snapshot provider.
+    /// </summary>
+    public const string BlobContainerClientServiceKey = "mississippi-blob-snapshots-container";
+
+    /// <summary>
+    ///     The keyed DI service key for the Blob service client used by the snapshot provider.
+    /// </summary>
+    public const string BlobServiceClientServiceKey = "mississippi-blob-snapshots";
+
+    /// <summary>
+    ///     The default Blob container name for snapshots.
+    /// </summary>
+    public const string ContainerName = "snapshots";
+
+    /// <summary>
+    ///     The default maximum uncompressed snapshot payload size in bytes.
+    /// </summary>
+    public const long DefaultMaximumSnapshotPayloadSizeBytes = 128L * 1024L * 1024L;
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageOptions.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageOptions.cs
@@ -1,0 +1,28 @@
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Options controlling Blob snapshot persistence.
+/// </summary>
+public sealed class SnapshotBlobStorageOptions
+{
+    /// <summary>
+    ///     Gets or sets the keyed service key used to resolve the <c>BlobServiceClient</c> from DI.
+    /// </summary>
+    public string BlobServiceClientServiceKey { get; set; } = SnapshotBlobDefaults.BlobServiceClientServiceKey;
+
+    /// <summary>
+    ///     Gets or sets the Blob container name used for snapshot storage.
+    /// </summary>
+    public string ContainerName { get; set; } = SnapshotBlobDefaults.ContainerName;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether stored snapshot payload bytes should be gzip-compressed.
+    /// </summary>
+    public bool EnableCompression { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the maximum allowed uncompressed snapshot payload size in bytes.
+    /// </summary>
+    public long MaximumSnapshotPayloadSizeBytes { get; set; } =
+        SnapshotBlobDefaults.DefaultMaximumSnapshotPayloadSizeBytes;
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageOptionsValidator.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageOptionsValidator.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Options;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Validates <see cref="SnapshotBlobStorageOptions" /> values.
+/// </summary>
+internal sealed class SnapshotBlobStorageOptionsValidator : IValidateOptions<SnapshotBlobStorageOptions>
+{
+    private static bool IsLowercaseLetterOrDigit(
+        char character
+    ) =>
+        ((character >= 'a') && (character <= 'z')) || ((character >= '0') && (character <= '9'));
+
+    private static bool IsValidContainerName(
+        string? value
+    )
+    {
+        if (string.IsNullOrWhiteSpace(value) || (value.Length < 3) || (value.Length > 63))
+        {
+            return false;
+        }
+
+        if (!IsLowercaseLetterOrDigit(value[0]) || !IsLowercaseLetterOrDigit(value[^1]))
+        {
+            return false;
+        }
+
+        bool previousWasDash = false;
+        foreach (char character in value)
+        {
+            if (IsLowercaseLetterOrDigit(character))
+            {
+                previousWasDash = false;
+                continue;
+            }
+
+            if ((character != '-') || previousWasDash)
+            {
+                return false;
+            }
+
+            previousWasDash = true;
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(
+        string? name,
+        SnapshotBlobStorageOptions options
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        List<string> failures = [];
+        if (string.IsNullOrWhiteSpace(options.BlobServiceClientServiceKey))
+        {
+            failures.Add("BlobServiceClientServiceKey must be provided.");
+        }
+
+        if (!IsValidContainerName(options.ContainerName))
+        {
+            failures.Add("ContainerName must be a valid Azure Blob container name.");
+        }
+
+        if (options.MaximumSnapshotPayloadSizeBytes <= 0)
+        {
+            failures.Add("MaximumSnapshotPayloadSizeBytes must be greater than zero.");
+        }
+
+        return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProvider.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProvider.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Mississippi.Tributary.Abstractions;
+using Mississippi.Tributary.Runtime.Storage.Abstractions;
+using Mississippi.Tributary.Runtime.Storage.Blobs.Diagnostics;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Azure Blob Storage implementation of <see cref="ISnapshotStorageProvider" />.
+/// </summary>
+internal sealed class SnapshotBlobStorageProvider : ISnapshotStorageProvider
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="SnapshotBlobStorageProvider" /> class.
+    /// </summary>
+    /// <param name="repository">The repository handling Blob snapshot persistence.</param>
+    /// <param name="logger">The logger for diagnostic output.</param>
+    public SnapshotBlobStorageProvider(
+        ISnapshotBlobRepository repository,
+        ILogger<SnapshotBlobStorageProvider> logger
+    )
+    {
+        Repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public string Format => "azure-blob";
+
+    private ILogger<SnapshotBlobStorageProvider> Logger { get; }
+
+    private ISnapshotBlobRepository Repository { get; }
+
+    /// <inheritdoc />
+    public async Task DeleteAllAsync(
+        SnapshotStreamKey streamKey,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Logger.DeletingAllSnapshots(streamKey);
+        await Repository.DeleteAllAsync(streamKey, cancellationToken).ConfigureAwait(false);
+        Logger.AllSnapshotsDeleted(streamKey);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(
+        SnapshotKey snapshotKey,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Logger.DeletingSnapshot(snapshotKey);
+        await Repository.DeleteAsync(snapshotKey, cancellationToken).ConfigureAwait(false);
+        SnapshotBlobStorageMetrics.RecordDelete(snapshotKey.Stream.SnapshotStorageName);
+        Logger.SnapshotDeleted(snapshotKey);
+    }
+
+    /// <inheritdoc />
+    public async Task PruneAsync(
+        SnapshotStreamKey streamKey,
+        IReadOnlyCollection<int> retainModuli,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(retainModuli);
+        Logger.PruningSnapshots(streamKey, retainModuli.Count);
+        int deletedCount =
+            await Repository.PruneAsync(streamKey, retainModuli, cancellationToken).ConfigureAwait(false);
+        SnapshotBlobStorageMetrics.RecordPrune(streamKey.SnapshotStorageName, deletedCount);
+        Logger.SnapshotsPruned(streamKey, deletedCount);
+    }
+
+    /// <inheritdoc />
+    public async Task<SnapshotEnvelope?> ReadAsync(
+        SnapshotKey snapshotKey,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Logger.ReadingSnapshot(snapshotKey);
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        SnapshotEnvelope? envelope = await Repository.ReadAsync(snapshotKey, cancellationToken).ConfigureAwait(false);
+        stopwatch.Stop();
+        bool found = envelope is not null;
+        SnapshotBlobStorageMetrics.RecordRead(
+            snapshotKey.Stream.SnapshotStorageName,
+            stopwatch.Elapsed.TotalMilliseconds,
+            found);
+        if (found)
+        {
+            Logger.SnapshotFound(snapshotKey);
+        }
+        else
+        {
+            Logger.SnapshotNotFound(snapshotKey);
+        }
+
+        return envelope;
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(
+        SnapshotKey snapshotKey,
+        SnapshotEnvelope snapshot,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        Logger.WritingSnapshot(snapshotKey);
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await Repository.WriteAsync(snapshotKey, snapshot, cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+            SnapshotBlobStorageMetrics.RecordWrite(
+                snapshotKey.Stream.SnapshotStorageName,
+                stopwatch.Elapsed.TotalMilliseconds,
+                true,
+                snapshot.DataSizeBytes);
+            Logger.SnapshotWritten(snapshotKey);
+        }
+        catch (Exception exception)
+        {
+            stopwatch.Stop();
+            SnapshotBlobStorageMetrics.RecordWrite(
+                snapshotKey.Stream.SnapshotStorageName,
+                stopwatch.Elapsed.TotalMilliseconds,
+                false,
+                snapshot.DataSizeBytes);
+            Logger.SnapshotWriteFailed(snapshotKey, exception);
+            throw;
+        }
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProviderLoggerExtensions.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProviderLoggerExtensions.cs
@@ -1,0 +1,164 @@
+using System;
+
+using Microsoft.Extensions.Logging;
+
+using Mississippi.Tributary.Abstractions;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     High-performance logging extensions for <see cref="SnapshotBlobStorageProvider" />.
+/// </summary>
+internal static partial class SnapshotBlobStorageProviderLoggerExtensions
+{
+    /// <summary>
+    ///     Logs when all snapshots for a stream were deleted.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="streamKey">The stream key.</param>
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "Deleted all Blob snapshots for stream '{StreamKey}'.")]
+    public static partial void AllSnapshotsDeleted(
+        this ILogger logger,
+        SnapshotStreamKey streamKey
+    );
+
+    /// <summary>
+    ///     Logs when all snapshots for a stream are being deleted.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="streamKey">The stream key.</param>
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Deleting all Blob snapshots for stream '{StreamKey}'.")]
+    public static partial void DeletingAllSnapshots(
+        this ILogger logger,
+        SnapshotStreamKey streamKey
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot delete begins.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    [LoggerMessage(EventId = 3, Level = LogLevel.Debug, Message = "Deleting Blob snapshot '{SnapshotKey}'.")]
+    public static partial void DeletingSnapshot(
+        this ILogger logger,
+        SnapshotKey snapshotKey
+    );
+
+    /// <summary>
+    ///     Logs when a prune operation begins.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="streamKey">The stream key.</param>
+    /// <param name="moduliCount">The number of retention moduli.</param>
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Information,
+        Message = "Pruning Blob snapshots for stream '{StreamKey}' with {ModuliCount} moduli.")]
+    public static partial void PruningSnapshots(
+        this ILogger logger,
+        SnapshotStreamKey streamKey,
+        int moduliCount
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot read begins.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    [LoggerMessage(EventId = 7, Level = LogLevel.Debug, Message = "Reading Blob snapshot '{SnapshotKey}'.")]
+    public static partial void ReadingSnapshot(
+        this ILogger logger,
+        SnapshotKey snapshotKey
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot delete completes.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    [LoggerMessage(EventId = 4, Level = LogLevel.Debug, Message = "Deleted Blob snapshot '{SnapshotKey}'.")]
+    public static partial void SnapshotDeleted(
+        this ILogger logger,
+        SnapshotKey snapshotKey
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot was found.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    [LoggerMessage(EventId = 8, Level = LogLevel.Debug, Message = "Found Blob snapshot '{SnapshotKey}'.")]
+    public static partial void SnapshotFound(
+        this ILogger logger,
+        SnapshotKey snapshotKey
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot was not found.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    [LoggerMessage(EventId = 9, Level = LogLevel.Debug, Message = "Blob snapshot '{SnapshotKey}' was not found.")]
+    public static partial void SnapshotNotFound(
+        this ILogger logger,
+        SnapshotKey snapshotKey
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot write fails.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    /// <param name="exception">The exception.</param>
+    [LoggerMessage(EventId = 12, Level = LogLevel.Error, Message = "Failed to write Blob snapshot '{SnapshotKey}'.")]
+    public static partial void SnapshotWriteFailed(
+        this ILogger logger,
+        SnapshotKey snapshotKey,
+        Exception exception
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot write completes.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    [LoggerMessage(EventId = 11, Level = LogLevel.Debug, Message = "Wrote Blob snapshot '{SnapshotKey}'.")]
+    public static partial void SnapshotWritten(
+        this ILogger logger,
+        SnapshotKey snapshotKey
+    );
+
+    /// <summary>
+    ///     Logs when a prune operation completes.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="streamKey">The stream key.</param>
+    /// <param name="deletedCount">The number of deleted snapshots.</param>
+    [LoggerMessage(
+        EventId = 6,
+        Level = LogLevel.Information,
+        Message = "Pruned {DeletedCount} Blob snapshots for stream '{StreamKey}'.")]
+    public static partial void SnapshotsPruned(
+        this ILogger logger,
+        SnapshotStreamKey streamKey,
+        int deletedCount
+    );
+
+    /// <summary>
+    ///     Logs when a snapshot write begins.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    [LoggerMessage(EventId = 10, Level = LogLevel.Debug, Message = "Writing Blob snapshot '{SnapshotKey}'.")]
+    public static partial void WritingSnapshot(
+        this ILogger logger,
+        SnapshotKey snapshotKey
+    );
+}

--- a/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProviderRegistrations.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProviderRegistrations.cs
@@ -1,0 +1,137 @@
+using System;
+
+using Azure.Storage.Blobs;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+using Mississippi.Tributary.Runtime.Storage.Abstractions;
+using Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs;
+
+/// <summary>
+///     Extension methods for registering Blob snapshot storage provider services.
+/// </summary>
+public static class SnapshotBlobStorageProviderRegistrations
+{
+    /// <summary>
+    ///     Registers Blob snapshot storage provider services using an externally provided keyed
+    ///     <see cref="BlobServiceClient" />.
+    /// </summary>
+    /// <param name="services">The service collection to update.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddBlobSnapshotStorageProvider(
+        this IServiceCollection services
+    )
+    {
+        services.AddOptions<SnapshotBlobStorageOptions>().ValidateOnStart();
+        services.TryAddEnumerable(
+            ServiceDescriptor
+                .Singleton<IValidateOptions<SnapshotBlobStorageOptions>, SnapshotBlobStorageOptionsValidator>());
+        services.AddSingleton<ISnapshotBlobOperations, SnapshotBlobOperations>();
+        services.AddSingleton<ISnapshotBlobRepository, SnapshotBlobRepository>();
+        services.RegisterSnapshotStorageProvider<SnapshotBlobStorageProvider>();
+        services.AddHostedService<SnapshotBlobContainerInitializer>();
+
+        // Caller must register a keyed BlobServiceClient with SnapshotBlobDefaults.BlobServiceClientServiceKey
+        // or override SnapshotBlobStorageOptions.BlobServiceClientServiceKey to a different keyed client.
+        services.AddKeyedSingleton<BlobContainerClient>(
+            SnapshotBlobDefaults.BlobContainerClientServiceKey,
+            (
+                provider,
+                _
+            ) =>
+            {
+                SnapshotBlobStorageOptions options =
+                    provider.GetRequiredService<IOptions<SnapshotBlobStorageOptions>>().Value;
+                BlobServiceClient blobServiceClient =
+                    provider.GetRequiredKeyedService<BlobServiceClient>(options.BlobServiceClientServiceKey);
+                return blobServiceClient.GetBlobContainerClient(options.ContainerName);
+            });
+        return services;
+    }
+
+    /// <summary>
+    ///     Creates and registers the keyed <see cref="BlobServiceClient" /> from the supplied connection string.
+    /// </summary>
+    /// <param name="services">The service collection to update.</param>
+    /// <param name="blobConnectionString">The Azure Blob Storage connection string.</param>
+    /// <param name="configureOptions">Optional options configuration.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddBlobSnapshotStorageProvider(
+        this IServiceCollection services,
+        string blobConnectionString,
+        Action<SnapshotBlobStorageOptions>? configureOptions = null
+    )
+    {
+        services.AddKeyedSingleton<BlobServiceClient>(
+            SnapshotBlobDefaults.BlobServiceClientServiceKey,
+            (
+                _,
+                _
+            ) => new(blobConnectionString));
+        if (configureOptions is not null)
+        {
+            services.Configure(configureOptions);
+        }
+
+        return services.AddBlobSnapshotStorageProvider();
+    }
+
+    /// <summary>
+    ///     Applies the provided options configuration and registers the Blob snapshot storage provider.
+    /// </summary>
+    /// <param name="services">The service collection to update.</param>
+    /// <param name="configureOptions">The options configuration action.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddBlobSnapshotStorageProvider(
+        this IServiceCollection services,
+        Action<SnapshotBlobStorageOptions> configureOptions
+    )
+    {
+        services.Configure(configureOptions);
+        return services.AddBlobSnapshotStorageProvider();
+    }
+
+    /// <summary>
+    ///     Binds options from configuration and registers the Blob snapshot storage provider.
+    /// </summary>
+    /// <param name="services">The service collection to update.</param>
+    /// <param name="configuration">The configuration section containing Blob snapshot storage settings.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddBlobSnapshotStorageProvider(
+        this IServiceCollection services,
+        IConfiguration configuration
+    )
+    {
+        services.Configure<SnapshotBlobStorageOptions>(configuration);
+        return services.AddBlobSnapshotStorageProvider();
+    }
+
+    /// <summary>
+    ///     Creates the keyed <see cref="BlobServiceClient" />, binds options from configuration, and registers the provider.
+    /// </summary>
+    /// <param name="services">The service collection to update.</param>
+    /// <param name="blobConnectionString">The Azure Blob Storage connection string.</param>
+    /// <param name="configuration">The configuration section containing Blob snapshot storage settings.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddBlobSnapshotStorageProvider(
+        this IServiceCollection services,
+        string blobConnectionString,
+        IConfiguration configuration
+    )
+    {
+        services.AddKeyedSingleton<BlobServiceClient>(
+            SnapshotBlobDefaults.BlobServiceClientServiceKey,
+            (
+                _,
+                _
+            ) => new(blobConnectionString));
+        services.Configure<SnapshotBlobStorageOptions>(configuration);
+        return services.AddBlobSnapshotStorageProvider();
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobCompression.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobCompression.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     Compresses and decompresses Blob snapshot payload bytes.
+/// </summary>
+internal static class SnapshotBlobCompression
+{
+    /// <summary>
+    ///     The metadata value indicating a gzip-compressed payload.
+    /// </summary>
+    public const string Gzip = "gzip";
+
+    /// <summary>
+    ///     The metadata value indicating an uncompressed payload.
+    /// </summary>
+    public const string None = "none";
+
+    private const int BufferSize = 81920;
+
+    /// <summary>
+    ///     Compresses the payload when compression is enabled.
+    /// </summary>
+    /// <param name="payload">The payload bytes.</param>
+    /// <param name="enableCompression">A value indicating whether gzip compression should be applied.</param>
+    /// <returns>The stored bytes and compression metadata.</returns>
+    public static SnapshotBlobCompressionResult Compress(
+        byte[] payload,
+        bool enableCompression
+    )
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        if (!enableCompression)
+        {
+            return new(None, payload);
+        }
+
+        using MemoryStream output = new();
+        using (GZipStream gzipStream = new(output, CompressionLevel.SmallestSize, true))
+        {
+            gzipStream.Write(payload, 0, payload.Length);
+        }
+
+        return new(Gzip, output.ToArray());
+    }
+
+    /// <summary>
+    ///     Decompresses stored payload bytes according to the stored compression metadata.
+    /// </summary>
+    /// <param name="compression">The stored compression value.</param>
+    /// <param name="storedBytes">The stored payload bytes before Base64 encoding.</param>
+    /// <param name="maximumPayloadSizeBytes">The maximum allowed uncompressed payload size in bytes.</param>
+    /// <returns>The uncompressed payload bytes.</returns>
+    public static byte[] Decompress(
+        string compression,
+        byte[] storedBytes,
+        long maximumPayloadSizeBytes = long.MaxValue
+    )
+    {
+        ArgumentNullException.ThrowIfNull(compression);
+        ArgumentNullException.ThrowIfNull(storedBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumPayloadSizeBytes);
+        if (string.Equals(compression, None, StringComparison.Ordinal))
+        {
+            if (storedBytes.LongLength > maximumPayloadSizeBytes)
+            {
+                throw new InvalidDataException(
+                    $"Uncompressed snapshot payload size '{storedBytes.LongLength}' exceeds the configured maximum '{maximumPayloadSizeBytes}'.");
+            }
+
+            return storedBytes;
+        }
+
+        if (!string.Equals(compression, Gzip, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Unsupported snapshot compression value '{compression}'.");
+        }
+
+        try
+        {
+            using MemoryStream input = new(storedBytes, false);
+            using GZipStream gzipStream = new(input, CompressionMode.Decompress);
+            using MemoryStream output = new();
+            byte[] buffer = new byte[BufferSize];
+            long totalBytesRead = 0;
+            while (true)
+            {
+                int bytesRead = gzipStream.Read(buffer, 0, buffer.Length);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                totalBytesRead += bytesRead;
+                if (totalBytesRead > maximumPayloadSizeBytes)
+                {
+                    throw new InvalidDataException(
+                        $"Decompressed snapshot payload size exceeds the configured maximum '{maximumPayloadSizeBytes}'.");
+                }
+
+                output.Write(buffer, 0, bytesRead);
+            }
+
+            return output.ToArray();
+        }
+        catch (InvalidDataException exception)
+        {
+            throw new InvalidDataException("Stored gzip snapshot payload is invalid.", exception);
+        }
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobCompressionResult.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobCompressionResult.cs
@@ -1,0 +1,12 @@
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     Represents the stored payload bytes and associated compression metadata.
+/// </summary>
+internal readonly record struct SnapshotBlobCompressionResult(string Compression, byte[] StoredBytes)
+{
+    /// <summary>
+    ///     Gets the number of stored bytes before Base64 encoding.
+    /// </summary>
+    public long StoredSizeBytes => StoredBytes.LongLength;
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobDocument.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobDocument.cs
@@ -1,0 +1,81 @@
+using System.Text.Json.Serialization;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     Blob JSON document representation of a snapshot.
+/// </summary>
+internal sealed class SnapshotBlobDocument
+{
+    /// <summary>
+    ///     The current JSON schema version.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>
+    ///     Gets the brook name identifying the event stream.
+    /// </summary>
+    [JsonPropertyName("brookName")]
+    public string BrookName { get; init; } = string.Empty;
+
+    /// <summary>
+    ///     Gets the compression metadata value.
+    /// </summary>
+    [JsonPropertyName("compression")]
+    public string Compression { get; init; } = SnapshotBlobCompression.None;
+
+    /// <summary>
+    ///     Gets the Base64-encoded stored payload bytes.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public string Data { get; init; } = string.Empty;
+
+    /// <summary>
+    ///     Gets the MIME type describing the payload bytes.
+    /// </summary>
+    [JsonPropertyName("dataContentType")]
+    public string DataContentType { get; init; } = string.Empty;
+
+    /// <summary>
+    ///     Gets the uncompressed payload size in bytes.
+    /// </summary>
+    [JsonPropertyName("dataSizeBytes")]
+    public long DataSizeBytes { get; init; }
+
+    /// <summary>
+    ///     Gets the entity identifier for the snapshot stream.
+    /// </summary>
+    [JsonPropertyName("entityId")]
+    public string EntityId { get; init; } = string.Empty;
+
+    /// <summary>
+    ///     Gets the reducers hash for the snapshot stream.
+    /// </summary>
+    [JsonPropertyName("reducersHash")]
+    public string ReducersHash { get; init; } = string.Empty;
+
+    /// <summary>
+    ///     Gets the JSON schema version.
+    /// </summary>
+    [JsonPropertyName("schemaVersion")]
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+
+    /// <summary>
+    ///     Gets the snapshot storage name for the snapshot stream.
+    /// </summary>
+    [JsonPropertyName("snapshotStorageName")]
+    public string SnapshotStorageName { get; init; } = string.Empty;
+
+    /// <summary>
+    ///     Gets the stored payload size in bytes before Base64 encoding.
+    /// </summary>
+    [JsonPropertyName("storedSizeBytes")]
+    public long StoredSizeBytes { get; init; }
+
+    /// <summary>
+    ///     Gets the snapshot version.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public long Version { get; init; }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobDocumentSerializer.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobDocumentSerializer.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     Serializes and deserializes Blob snapshot JSON documents.
+/// </summary>
+internal static class SnapshotBlobDocumentSerializer
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = false,
+    };
+
+    /// <summary>
+    ///     Deserializes a Blob snapshot document.
+    /// </summary>
+    /// <param name="document">The serialized JSON document.</param>
+    /// <returns>The deserialized document.</returns>
+    public static SnapshotBlobDocument Deserialize(
+        BinaryData document
+    )
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        try
+        {
+            SnapshotBlobDocument? result =
+                JsonSerializer.Deserialize<SnapshotBlobDocument>(document.ToMemory().Span, SerializerOptions);
+            if (result is null)
+            {
+                throw new InvalidDataException("Snapshot Blob document JSON deserialized to null.");
+            }
+
+            return result;
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException("Snapshot Blob document JSON is invalid.", exception);
+        }
+    }
+
+    /// <summary>
+    ///     Serializes a Blob snapshot document.
+    /// </summary>
+    /// <param name="document">The document to serialize.</param>
+    /// <returns>The serialized JSON document.</returns>
+    public static BinaryData Serialize(
+        SnapshotBlobDocument document
+    )
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return BinaryData.FromBytes(JsonSerializer.SerializeToUtf8Bytes(document, SerializerOptions));
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobOperations.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobOperations.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+using Microsoft.Extensions.DependencyInjection;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     Azure Blob SDK implementation of <see cref="ISnapshotBlobOperations" />.
+/// </summary>
+internal sealed class SnapshotBlobOperations : ISnapshotBlobOperations
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="SnapshotBlobOperations" /> class.
+    /// </summary>
+    /// <param name="blobContainerClient">The keyed Blob container client for snapshot storage.</param>
+    public SnapshotBlobOperations(
+        [FromKeyedServices(SnapshotBlobDefaults.BlobContainerClientServiceKey)]
+        BlobContainerClient blobContainerClient
+    ) =>
+        BlobContainerClient = blobContainerClient ?? throw new ArgumentNullException(nameof(blobContainerClient));
+
+    private BlobContainerClient BlobContainerClient { get; }
+
+    /// <inheritdoc />
+    public async Task CreateContainerIfNotExistsAsync(
+        CancellationToken cancellationToken = default
+    ) =>
+        _ = await BlobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteIfExistsAsync(
+        string blobName,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(blobName);
+        Response<bool> response = await BlobContainerClient
+            .DeleteBlobIfExistsAsync(blobName, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return response.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task<BinaryData?> DownloadAsync(
+        string blobName,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(blobName);
+        BlobClient blobClient = BlobContainerClient.GetBlobClient(blobName);
+        try
+        {
+            BlobDownloadResult result = await blobClient.DownloadContentAsync(cancellationToken).ConfigureAwait(false);
+            return result.Content;
+        }
+        catch (RequestFailedException exception) when (exception.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> ListBlobNamesAsync(
+        string prefix,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        await foreach (BlobItem blobItem in BlobContainerClient.GetBlobsAsync(
+                           BlobTraits.None,
+                           BlobStates.None,
+                           prefix,
+                           cancellationToken))
+        {
+            yield return blobItem.Name;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task UploadAsync(
+        string blobName,
+        BinaryData document,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(blobName);
+        ArgumentNullException.ThrowIfNull(document);
+        BlobClient blobClient = BlobContainerClient.GetBlobClient(blobName);
+        await blobClient.UploadAsync(
+                document,
+                new BlobUploadOptions
+                {
+                    HttpHeaders = new()
+                    {
+                        ContentType = "application/json",
+                    },
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobPath.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobPath.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+using Mississippi.Tributary.Abstractions;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     Builds and parses Blob names for snapshot documents.
+/// </summary>
+internal static class SnapshotBlobPath
+{
+    private const string BlobExtension = ".json";
+
+    /// <summary>
+    ///     Builds the Blob name for a specific snapshot version.
+    /// </summary>
+    /// <param name="snapshotKey">The snapshot key.</param>
+    /// <returns>The Blob name.</returns>
+    public static string BuildSnapshotBlobName(
+        SnapshotKey snapshotKey
+    ) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{BuildStreamPrefix(snapshotKey.Stream)}{snapshotKey.Version:D20}{BlobExtension}");
+
+    /// <summary>
+    ///     Builds the Blob prefix for a snapshot stream.
+    /// </summary>
+    /// <param name="streamKey">The snapshot stream key.</param>
+    /// <returns>The Blob prefix.</returns>
+    public static string BuildStreamPrefix(
+        SnapshotStreamKey streamKey
+    )
+    {
+        ArgumentNullException.ThrowIfNull(streamKey.BrookName);
+        string streamKeyText = streamKey.ToString();
+        byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(streamKeyText));
+        string hash = Convert.ToHexString(hashBytes);
+        return $"v1/streams/{hash}/versions/";
+    }
+
+    /// <summary>
+    ///     Attempts to parse a version from a Blob name under the given stream.
+    /// </summary>
+    /// <param name="blobName">The Blob name.</param>
+    /// <param name="streamKey">The stream key.</param>
+    /// <param name="version">The parsed version when successful.</param>
+    /// <returns><c>true</c> when the Blob name matches the stream path and contains a valid version.</returns>
+    public static bool TryParseVersionFromBlobName(
+        string blobName,
+        SnapshotStreamKey streamKey,
+        out long version
+    )
+    {
+        ArgumentNullException.ThrowIfNull(blobName);
+        string prefix = BuildStreamPrefix(streamKey);
+        if (!blobName.StartsWith(prefix, StringComparison.Ordinal) ||
+            !blobName.EndsWith(BlobExtension, StringComparison.Ordinal))
+        {
+            version = default;
+            return false;
+        }
+
+        string versionText = blobName[prefix.Length..^BlobExtension.Length];
+        if ((versionText.Length != 20) ||
+            !long.TryParse(versionText, NumberStyles.None, CultureInfo.InvariantCulture, out version))
+        {
+            version = default;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobRepository.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobRepository.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Mississippi.Tributary.Abstractions;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     Blob-backed implementation of <see cref="ISnapshotBlobRepository" />.
+/// </summary>
+internal sealed class SnapshotBlobRepository : ISnapshotBlobRepository
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="SnapshotBlobRepository" /> class.
+    /// </summary>
+    /// <param name="operations">The Blob operations abstraction.</param>
+    /// <param name="options">The Blob snapshot storage options.</param>
+    /// <param name="logger">The logger for diagnostic output.</param>
+    public SnapshotBlobRepository(
+        ISnapshotBlobOperations operations,
+        IOptions<SnapshotBlobStorageOptions> options,
+        ILogger<SnapshotBlobRepository> logger
+    )
+    {
+        Operations = operations ?? throw new ArgumentNullException(nameof(operations));
+        Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    private ILogger<SnapshotBlobRepository> Logger { get; }
+
+    private ISnapshotBlobOperations Operations { get; }
+
+    private SnapshotBlobStorageOptions Options { get; }
+
+    private static byte[] DecodeStoredBytes(
+        string blobName,
+        string base64Payload
+    )
+    {
+        try
+        {
+            return Convert.FromBase64String(base64Payload);
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidDataException(
+                $"Blob snapshot '{blobName}' contains invalid Base64 payload data.",
+                exception);
+        }
+    }
+
+    private static void ValidateDeclaredPayloadSize(
+        string blobName,
+        long dataSizeBytes,
+        long maximumSnapshotPayloadSizeBytes
+    )
+    {
+        if ((dataSizeBytes < 0) || (dataSizeBytes > maximumSnapshotPayloadSizeBytes))
+        {
+            throw new InvalidDataException(
+                $"Blob snapshot '{blobName}' declares an invalid DataSizeBytes value '{dataSizeBytes}'.");
+        }
+    }
+
+    private static void ValidateDocument(
+        SnapshotKey snapshotKey,
+        string blobName,
+        SnapshotBlobDocument document
+    )
+    {
+        if (document.SchemaVersion != SnapshotBlobDocument.CurrentSchemaVersion)
+        {
+            throw new InvalidDataException(
+                $"Blob snapshot '{blobName}' uses unsupported schema version '{document.SchemaVersion}'.");
+        }
+
+        if (!string.Equals(document.BrookName, snapshotKey.Stream.BrookName, StringComparison.Ordinal) ||
+            !string.Equals(
+                document.SnapshotStorageName,
+                snapshotKey.Stream.SnapshotStorageName,
+                StringComparison.Ordinal) ||
+            !string.Equals(document.EntityId, snapshotKey.Stream.EntityId, StringComparison.Ordinal) ||
+            !string.Equals(document.ReducersHash, snapshotKey.Stream.ReducersHash, StringComparison.Ordinal) ||
+            (document.Version != snapshotKey.Version))
+        {
+            throw new InvalidDataException($"Blob snapshot '{blobName}' does not match the requested snapshot key.");
+        }
+    }
+
+    private static void ValidateReducerHash(
+        SnapshotKey snapshotKey,
+        SnapshotEnvelope snapshot
+    )
+    {
+        if (!string.Equals(snapshot.ReducerHash, snapshotKey.Stream.ReducersHash, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Snapshot envelope ReducerHash '{snapshot.ReducerHash}' does not match snapshot key reducers hash '{snapshotKey.Stream.ReducersHash}'.",
+                nameof(snapshot));
+        }
+    }
+
+    private static void ValidateSnapshotEnvelope(
+        SnapshotEnvelope snapshot
+    )
+    {
+        long actualLength = snapshot.Data.Length;
+        if (snapshot.DataSizeBytes != actualLength)
+        {
+            throw new ArgumentException(
+                $"Snapshot envelope DataSizeBytes '{snapshot.DataSizeBytes}' does not match payload length '{actualLength}'.",
+                nameof(snapshot));
+        }
+    }
+
+    private static void ValidateSnapshotPayloadLimit(
+        SnapshotEnvelope snapshot,
+        long maximumSnapshotPayloadSizeBytes
+    )
+    {
+        if (snapshot.DataSizeBytes > maximumSnapshotPayloadSizeBytes)
+        {
+            throw new ArgumentException(
+                $"Snapshot envelope DataSizeBytes '{snapshot.DataSizeBytes}' exceeds configured maximum '{maximumSnapshotPayloadSizeBytes}'.",
+                nameof(snapshot));
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAllAsync(
+        SnapshotStreamKey streamKey,
+        CancellationToken cancellationToken = default
+    )
+    {
+        string prefix = SnapshotBlobPath.BuildStreamPrefix(streamKey);
+        Logger.DeletingAllSnapshots(prefix);
+        await foreach (string blobName in Operations.ListBlobNamesAsync(prefix, cancellationToken))
+        {
+            if (!SnapshotBlobPath.TryParseVersionFromBlobName(blobName, streamKey, out long _))
+            {
+                continue;
+            }
+
+            await Operations.DeleteIfExistsAsync(blobName, cancellationToken).ConfigureAwait(false);
+            Logger.SnapshotDeleted(blobName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(
+        SnapshotKey snapshotKey,
+        CancellationToken cancellationToken = default
+    )
+    {
+        string blobName = SnapshotBlobPath.BuildSnapshotBlobName(snapshotKey);
+        await Operations.DeleteIfExistsAsync(blobName, cancellationToken).ConfigureAwait(false);
+        Logger.SnapshotDeleted(blobName);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> PruneAsync(
+        SnapshotStreamKey streamKey,
+        IReadOnlyCollection<int> retainModuli,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(retainModuli);
+        string prefix = SnapshotBlobPath.BuildStreamPrefix(streamKey);
+        Logger.PruningSnapshots(prefix, retainModuli.Count);
+        List<(string BlobName, long Version)> versions = [];
+        await foreach (string blobName in Operations.ListBlobNamesAsync(prefix, cancellationToken))
+        {
+            if (SnapshotBlobPath.TryParseVersionFromBlobName(blobName, streamKey, out long version))
+            {
+                versions.Add((blobName, version));
+            }
+        }
+
+        if (versions.Count == 0)
+        {
+            return 0;
+        }
+
+        long maxVersion = versions.Max(item => item.Version);
+        HashSet<long> retainedVersions = new(
+            versions.Where(item => retainModuli.Any(modulus => (modulus != 0) && ((item.Version % modulus) == 0)))
+                .Select(item => item.Version));
+        retainedVersions.Add(maxVersion);
+        int deletedCount = 0;
+        foreach ((string blobName, long version) in versions)
+        {
+            if (retainedVersions.Contains(version))
+            {
+                continue;
+            }
+
+            if (await Operations.DeleteIfExistsAsync(blobName, cancellationToken).ConfigureAwait(false))
+            {
+                deletedCount++;
+                Logger.SnapshotDeleted(blobName);
+            }
+        }
+
+        return deletedCount;
+    }
+
+    /// <inheritdoc />
+    public async Task<SnapshotEnvelope?> ReadAsync(
+        SnapshotKey snapshotKey,
+        CancellationToken cancellationToken = default
+    )
+    {
+        string blobName = SnapshotBlobPath.BuildSnapshotBlobName(snapshotKey);
+        BinaryData? documentPayload = await Operations.DownloadAsync(blobName, cancellationToken).ConfigureAwait(false);
+        if (documentPayload is null)
+        {
+            Logger.SnapshotNotFound(blobName);
+            return null;
+        }
+
+        try
+        {
+            SnapshotBlobDocument document = SnapshotBlobDocumentSerializer.Deserialize(documentPayload);
+            ValidateDocument(snapshotKey, blobName, document);
+            byte[] storedBytes = DecodeStoredBytes(blobName, document.Data);
+            if (storedBytes.LongLength != document.StoredSizeBytes)
+            {
+                throw new InvalidDataException($"Stored payload size mismatch for Blob '{blobName}'.");
+            }
+
+            ValidateDeclaredPayloadSize(blobName, document.DataSizeBytes, Options.MaximumSnapshotPayloadSizeBytes);
+            byte[] payload = SnapshotBlobCompression.Decompress(
+                document.Compression,
+                storedBytes,
+                Options.MaximumSnapshotPayloadSizeBytes);
+            if (payload.LongLength != document.DataSizeBytes)
+            {
+                throw new InvalidDataException($"Uncompressed payload size mismatch for Blob '{blobName}'.");
+            }
+
+            Logger.SnapshotRead(blobName);
+            return new()
+            {
+                Data = ImmutableArray.CreateRange(payload),
+                DataContentType = document.DataContentType,
+                DataSizeBytes = document.DataSizeBytes,
+                ReducerHash = document.ReducersHash,
+            };
+        }
+        catch (InvalidDataException exception)
+        {
+            Logger.InvalidSnapshotDocument(blobName, exception.Message, exception);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(
+        SnapshotKey snapshotKey,
+        SnapshotEnvelope snapshot,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ValidateSnapshotEnvelope(snapshot);
+        ValidateReducerHash(snapshotKey, snapshot);
+        ValidateSnapshotPayloadLimit(snapshot, Options.MaximumSnapshotPayloadSizeBytes);
+        byte[] payload = snapshot.Data.ToArray();
+        SnapshotBlobCompressionResult compression = SnapshotBlobCompression.Compress(
+            payload,
+            Options.EnableCompression);
+        SnapshotBlobDocument document = new()
+        {
+            SchemaVersion = SnapshotBlobDocument.CurrentSchemaVersion,
+            BrookName = snapshotKey.Stream.BrookName,
+            SnapshotStorageName = snapshotKey.Stream.SnapshotStorageName,
+            EntityId = snapshotKey.Stream.EntityId,
+            ReducersHash = snapshot.ReducerHash,
+            Version = snapshotKey.Version,
+            DataContentType = snapshot.DataContentType,
+            DataSizeBytes = snapshot.DataSizeBytes,
+            Compression = compression.Compression,
+            StoredSizeBytes = compression.StoredSizeBytes,
+            Data = Convert.ToBase64String(compression.StoredBytes),
+        };
+        string blobName = SnapshotBlobPath.BuildSnapshotBlobName(snapshotKey);
+        await Operations.UploadAsync(blobName, SnapshotBlobDocumentSerializer.Serialize(document), cancellationToken)
+            .ConfigureAwait(false);
+        Logger.SnapshotUploaded(blobName);
+    }
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobRepositoryLoggerExtensions.cs
+++ b/src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobRepositoryLoggerExtensions.cs
@@ -1,0 +1,98 @@
+using System;
+
+using Microsoft.Extensions.Logging;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+/// <summary>
+///     High-performance logging extensions for <see cref="SnapshotBlobRepository" />.
+/// </summary>
+internal static partial class SnapshotBlobRepositoryLoggerExtensions
+{
+    /// <summary>
+    ///     Logs when all snapshots for a prefix are being deleted.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="prefix">The Blob prefix.</param>
+    [LoggerMessage(EventId = 1, Level = LogLevel.Debug, Message = "Deleting Blob snapshots under prefix '{Prefix}'.")]
+    public static partial void DeletingAllSnapshots(
+        this ILogger logger,
+        string prefix
+    );
+
+    /// <summary>
+    ///     Logs when a Blob snapshot document is invalid.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="blobName">The Blob name.</param>
+    /// <param name="reason">The failure reason.</param>
+    /// <param name="exception">The exception.</param>
+    [LoggerMessage(EventId = 6, Level = LogLevel.Error, Message = "Blob snapshot '{BlobName}' is invalid: {Reason}")]
+    public static partial void InvalidSnapshotDocument(
+        this ILogger logger,
+        string blobName,
+        string reason,
+        Exception exception
+    );
+
+    /// <summary>
+    ///     Logs when a prune operation begins.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="prefix">The Blob prefix.</param>
+    /// <param name="moduliCount">The number of moduli.</param>
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Debug,
+        Message = "Pruning Blob snapshots under prefix '{Prefix}' with {ModuliCount} moduli.")]
+    public static partial void PruningSnapshots(
+        this ILogger logger,
+        string prefix,
+        int moduliCount
+    );
+
+    /// <summary>
+    ///     Logs when a Blob snapshot was deleted.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="blobName">The Blob name.</param>
+    [LoggerMessage(EventId = 2, Level = LogLevel.Debug, Message = "Deleted Blob snapshot '{BlobName}'.")]
+    public static partial void SnapshotDeleted(
+        this ILogger logger,
+        string blobName
+    );
+
+    /// <summary>
+    ///     Logs when a Blob snapshot is missing.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="blobName">The Blob name.</param>
+    [LoggerMessage(EventId = 5, Level = LogLevel.Debug, Message = "Blob snapshot '{BlobName}' was not found.")]
+    public static partial void SnapshotNotFound(
+        this ILogger logger,
+        string blobName
+    );
+
+    /// <summary>
+    ///     Logs when a Blob snapshot read succeeds.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="blobName">The Blob name.</param>
+    [LoggerMessage(EventId = 4, Level = LogLevel.Debug, Message = "Read Blob snapshot '{BlobName}'.")]
+    public static partial void SnapshotRead(
+        this ILogger logger,
+        string blobName
+    );
+
+    /// <summary>
+    ///     Logs when a Blob snapshot upload succeeds.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="blobName">The Blob name.</param>
+    [LoggerMessage(EventId = 7, Level = LogLevel.Debug, Message = "Uploaded Blob snapshot '{BlobName}'.")]
+    public static partial void SnapshotUploaded(
+        this ILogger logger,
+        string blobName
+    );
+}

--- a/src/Tributary.Runtime.Storage.Blobs/Tributary.Runtime.Storage.Blobs.csproj
+++ b/src/Tributary.Runtime.Storage.Blobs/Tributary.Runtime.Storage.Blobs.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common.Abstractions\Common.Abstractions.csproj" />
+    <ProjectReference Include="..\Tributary.Abstractions\Tributary.Abstractions.csproj" />
+    <ProjectReference Include="..\Tributary.Runtime.Storage.Abstractions\Tributary.Runtime.Storage.Abstractions.csproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <Description>Azure Blob Storage provider for Tributary snapshot storage.</Description>
+  </PropertyGroup>
+</Project>

--- a/src/Tributary.Runtime.Storage.Blobs/packages.lock.json
+++ b/src/Tributary.Runtime.Storage.Blobs/packages.lock.json
@@ -1,0 +1,727 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Azure.Storage.Blobs": {
+        "type": "Direct",
+        "requested": "[12.28.0, )",
+        "resolved": "12.28.0",
+        "contentHash": "OK6slT3Hq3Yp2HWA0e23YHheHzKNbYjBZOwdT4fQ1iMH6I/8e6X8kAJLuKqVUeFBy160QSwhsynA3HxhVSHEcg==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "Azure.Storage.Common": "12.27.0"
+        }
+      },
+      "IDisposableAnalyzers": {
+        "type": "Direct",
+        "requested": "[4.0.8, )",
+        "resolved": "4.0.8",
+        "contentHash": "vNi4NMG0CcJyjXxiNDcQ21FwV/whM9o9OEZKD+oP7tuxAqFEzX/x5OhC3OZJqW/w+8GOtCmJPBquYgMWgz0rfQ=="
+      },
+      "Microsoft.CodeAnalysis.NetAnalyzers": {
+        "type": "Direct",
+        "requested": "[10.0.300, )",
+        "resolved": "10.0.300",
+        "contentHash": "WsPMVkfrmoZ0qKSasuVtYaxnd/MvqPOz7ZXld5NzyF8/kwwtPGjtmEKp4xDHG+pj4QqETpSVfkmKa0UFu/n1GQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "MoOWFPT88/pDfmWpbU9PydKRX/rJFQkliowE/L9wbQcl94IicUphb5BFgepkWiDkYYxPnuEqjN4buzOGW4vJpQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Direct",
+        "requested": "[17.14.15, )",
+        "resolved": "17.14.15",
+        "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.26.0.140279, )",
+        "resolved": "10.26.0.140279",
+        "contentHash": "n6+KDAbvKCJs0oYIQlxFdsmvcj1YSJ7TiqEd5jYq58T1s1Q4bwymFMeVFGDUyDKqSH9YO/7Fobvm0u9WJ7MaRQ=="
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Direct",
+        "requested": "[1.2.0.556, )",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.51.1",
+        "contentHash": "JRANrRvN5O5FFRh+pMUb8qqWU7jBQ39qXEbVr7Rkb1/s7rqc6RSzVHKGBz5Ro1gDy2WSGjG5YEOJKpPIBiCMcA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.2",
+          "System.ClientModel": "1.9.0",
+          "System.Memory.Data": "10.0.1"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.27.0",
+        "contentHash": "PBucMNzot6cYyN0isdte50iPCefJ4Ylg0B+KP4kxmqsc3ciOiDYh1MwVV6fPZPjoPnPvNRLN9TI6J5hgNf4huA==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.AspNetCore.Connections.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "i016BNW1Yqd5r+lfgWb4BiPjMuCXn+HXYgdbAPLZRkoNw9SSRP58/8AkdPOsWEXRL5BVNJ066CO60HFP99s6QQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Features": "10.0.3"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "qE5JhRoeJbAipLqpUCZyNfNwnpAvUttXgIQDnTiJ15d8ji+/bPgoPkB3xLzK5cQTobN2D2ditUesUlDHb7p3Pg=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "qVytXuCHQCIJcOsJJnp+1mNCAtiWuLqI0qhCcByFuyxDifthefEWX3fVAXbaxn1lDP2iR1KH44Oq7tvmT7dBHg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "jBm6bpc5OM2VHM/QYVUyD78xweFzble6UsIt7GUnQAwCm07hktFaUBtRfO7viLGg5qPbc4ByteNB7DeVAYNSfA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "/MLsBbLpwDxsU+7DDNwasf2mKrpMSOWEL377gNZTy5waFkCYvS3GVaLIz6bvikH4rAwHrCOxHw0t/5iCoImYCA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "mGGMOA9nkET8OVsQfS41o66eWkckBzNHJK6+5VbLQ2YdyqKphcv27uDZxLf4exSl+5QxLnHkN+W/4qEDgyvCPA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "f6FiscfqlLrNUR2x7XcMqMGz5ZFRwTvezZuebIn4v2ste0nL/sEZ7pdveDXqDyonVv/QTKT8vvIEqTQCczzsOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Json": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "31kRjr1fgdJO1UZ/AsjL2noqwht+juHMQ8c/oh8CEsDhlM2+0zwVZVsZjxSfOFiPtn5+6kRGuvSbLAufAPT0kA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "tc0R6i2T+138taoxFPQXb7Sy/4rtq4ytoJrAt4fNGs6k89mHpEhZnXUNgaFKwwb5Ud5rIUeLC6tfpsuHNwiWqg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "U+oquaPxFdY8lYeEIWO/AD7jDIl9sPW6aVWMQRHU/pZ/SWpLcOrAj2fcLe1HwXl4sYw1ONI56K/eELT3xr4RRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "8qLl5LXtcj6Z8yPbHAA/a57fvvl9nUCdi59AJFuixcWM4wSuENZ8jjoRATOKs/I4vOi/bDe0d5LqGSSLE634eA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "oM7pl8uJz8WRPRlh4AGQS61aeV9GOfTu89yqTiRSYyyMuCNVkbNra9zEk7ApyJ/sZrUpbjOZCRHuitCEsTWghg=="
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "PBlaoYeusaxNYyN4WFjzcXWlUDSvLUPxy/e6oP1SONOOYA/oBWT2uBmFGJMV9VTtXiXXxCB39LqlYWbsWE4UKA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "7sRvbBH3icaV9qil8fyBKmR+yEZ0yDU6Bq/KgBwswS36164yGaxbf7Kd4hD1iHZ2GfvyoJWWqBUBm9QX/IASAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "OoH8AcYCq74ab5XUIQc84CZk54G/cU+JztiMXgNKGkomJOeuistTMg0PWPC4VXXMSVBEGWJuMDEBttOrHyXe8w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "1V1oRR+0DKyetPKI4POn7+jXH4kI1D69R/Rjje/4/BSkTM2iUCsRkr7Q0gDyXayhCXgPEf/P19kgwN5t0s/p8w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "System.Diagnostics.EventLog": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "r2hIVkSrb+f8FqcguHqlzyQ8lNGCtWsOPY9+OzJinrqdzQfszS8fXkHVcNHW4uK6WFxI2tPSiGdms2SeRJq8hg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "dQKlVXzqflsv5X8iDlAN5YmTL1GcLCrOLKo1s9PNdfjqxeu0S/jmWTfiLGno+8+o1qFL3+VFAH5/ftmypN+sPw=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
+      },
+      "Microsoft.Orleans.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "66KYgO0kFFzozC54xQoSypAB4oJ2WKnMZ0ZIUtR4SuSoTCuy5NfIsL9oyiU/S0Zo3NSlXrYY/Zfmv/cwC4dYaw=="
+      },
+      "Microsoft.Orleans.CodeGenerator": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "6bLb87arLNOCEi4bg7jOSJcPxw9RtpacXOHV6LQC9IIf6vX6975YLFmjiD+Hqy4IV8HK3qL4pk3PXY4NW0SBbw=="
+      },
+      "Microsoft.Orleans.Core": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "aaFZ7XDzm4iIEgrwrojXaiLENQtVb22s/LeRVCJF9A270HmZASi8apF4y+zlAEqnD57VMw3JDXW7uBIjlKwq3w==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.3",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
+          "Microsoft.Extensions.Configuration.Json": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyModel": "10.0.3",
+          "Microsoft.Extensions.Hosting": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Console": "10.0.3",
+          "Microsoft.Extensions.Logging.Debug": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
+          "Microsoft.Orleans.Analyzers": "10.1.0",
+          "Microsoft.Orleans.CodeGenerator": "10.1.0",
+          "Microsoft.Orleans.Core.Abstractions": "10.1.0",
+          "Newtonsoft.Json": "13.0.4",
+          "System.IO.Hashing": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Microsoft.Orleans.Core.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "aik7fJFyDHuLgXzzyHc63rWoxBdIttehggZRe5q16/lmVIQ3v51yoyjE8xaH++oSkuYcpz3z+KpKdYyrBBA3PA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyModel": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Orleans.Analyzers": "10.1.0",
+          "Microsoft.Orleans.CodeGenerator": "10.1.0",
+          "Microsoft.Orleans.Serialization": "10.1.0",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "Microsoft.Orleans.Runtime": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "MVp0jPbnC55DxC7P9XhruHcKpbGED5TN+jMvM5BYFm+KyA+A506eL0DA53uwAYo28k1vzYe4K83O1bqCRLe9vw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.3",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
+          "Microsoft.Extensions.Configuration.Json": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyModel": "10.0.3",
+          "Microsoft.Extensions.Hosting": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Console": "10.0.3",
+          "Microsoft.Extensions.Logging.Debug": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
+          "Microsoft.Orleans.Analyzers": "10.1.0",
+          "Microsoft.Orleans.CodeGenerator": "10.1.0",
+          "Microsoft.Orleans.Core": "10.1.0",
+          "Newtonsoft.Json": "13.0.4",
+          "System.IO.Hashing": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Microsoft.Orleans.Serialization": {
+        "type": "Transitive",
+        "resolved": "10.1.0",
+        "contentHash": "kEVMZVUWwTpQcmlf+KNEM22xGNsRNsDryq1Wm93QvQpRRkVwbFf0vPFlPgyrhSgqQiS/ZJvxu/NReGgBPp3FVg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyModel": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Orleans.Analyzers": "10.1.0",
+          "Microsoft.Orleans.CodeGenerator": "10.1.0",
+          "Microsoft.Orleans.Serialization.Abstractions": "10.1.0",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "1wdwKtMMMEFEYsxJmtrOd3G+7zVOVO3MlVZAsbKv9H0PnIx6J27fYAarMn0eQS0vKJPQL018DOb7YRK1O97p0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.2",
+          "System.Memory.Data": "10.0.1"
+        }
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "+bZnyzt0/vt4g3QSllhsRNGTpa09p7Juy5K8spcK73cOTOefu4+HoY89hZOgIOmzB5A4hqPyEDKnzra7KKnhZw=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
+      },
+      "Mississippi.Brooks.Abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "CloudNative.CloudEvents": "[2.8.0, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.8, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.0.8, )",
+          "Microsoft.Orleans.Sdk": "[10.1.0, )",
+          "Microsoft.Orleans.Streaming": "[10.1.0, )"
+        }
+      },
+      "Mississippi.Common.Abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
+          "Microsoft.Orleans.Sdk": "[10.1.0, )"
+        }
+      },
+      "Mississippi.Tributary.Abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Orleans.Sdk": "[10.1.0, )",
+          "Mississippi.Brooks.Abstractions": "[1.0.0, )"
+        }
+      },
+      "Mississippi.Tributary.Runtime.Storage.Abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.0.8, )",
+          "Mississippi.Tributary.Abstractions": "[1.0.0, )"
+        }
+      },
+      "CloudNative.CloudEvents": {
+        "type": "CentralTransitive",
+        "requested": "[2.8.0, )",
+        "resolved": "2.8.0",
+        "contentHash": "RvabvAQV7u3FZcZL5UlRmFz3/T5nMl86GpChpRvHKRHbO+/I4LBcZ0xRqYnNfAh30gM+h/JkSBHEnbhl0zmGtA=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+      },
+      "Microsoft.Extensions.Features": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "djFt1Jt+2uREWWVQiiA4ilYBDtHHY7nK08c5K8xBD9+XFNw3KDVprylrMkH08bZGK3ZHRAkS7JDV9srfLrcm/g=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "ssbRCALcbBXfQPXLr4bZ3FVlbnDzeR0F6hPKDUCZLPQul7oBeSGaJq+XLUjwYaptOs4TN5cSy1q6LVLPWFgjKQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.3",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.3",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Json": "10.0.3",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Diagnostics": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.3",
+          "Microsoft.Extensions.Logging.Console": "10.0.3",
+          "Microsoft.Extensions.Logging.Debug": "10.0.3",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.3",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.3",
+        "contentHash": "8D9Er1cGXNjNDIB+VLBNHn386L5ls2FoiG9a6o12gyn+GG3w6jdfUhzT8dtBnKcevE7/fsVA8MS3FBgFfClFtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Orleans.Sdk": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "Wqj9ynNNgRk7FTyoxFYDe39R6Y2irATOgQFBH7T3xAOAVLdaEIXEocH4rdbhQrq03WrJUbuOVQdARFDiLYnixw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.3",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
+          "Microsoft.Extensions.Configuration.Json": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyModel": "10.0.3",
+          "Microsoft.Extensions.Hosting": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Console": "10.0.3",
+          "Microsoft.Extensions.Logging.Debug": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
+          "Microsoft.Orleans.Analyzers": "10.1.0",
+          "Microsoft.Orleans.CodeGenerator": "10.1.0",
+          "Microsoft.Orleans.Core": "10.1.0",
+          "Newtonsoft.Json": "13.0.4",
+          "System.IO.Hashing": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Microsoft.Orleans.Serialization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.1.0",
+        "contentHash": "+OqJ86TeiCN3ri+fNlymd7Q+LZBf+3F2Xdq+rngDc2q+vKF7dWP5L4H0ss3LHs07Otzm3lUGt8b2Co1eSvDI5A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Orleans.Streaming": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "Gg3dpjSNy0hY21BRb4Hi8dhBBJsBk5DqVIHI0GIY0WrzU1u2WCnG9U3Ysi7Z1REht61PTjPpN565wLroKGjkDg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.3",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
+          "Microsoft.Extensions.Configuration.Json": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyModel": "10.0.3",
+          "Microsoft.Extensions.Hosting": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Console": "10.0.3",
+          "Microsoft.Extensions.Logging.Debug": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
+          "Microsoft.Orleans.Analyzers": "10.1.0",
+          "Microsoft.Orleans.CodeGenerator": "10.1.0",
+          "Microsoft.Orleans.Runtime": "10.1.0",
+          "Newtonsoft.Json": "13.0.4",
+          "System.IO.Hashing": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "CentralTransitive",
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      }
+    }
+  }
+}

--- a/tests/Architecture.L0Tests/Architecture.L0Tests.csproj
+++ b/tests/Architecture.L0Tests/Architecture.L0Tests.csproj
@@ -22,6 +22,7 @@
         <ProjectReference Include="..\..\src\Tributary.Runtime\Tributary.Runtime.csproj" />
         <ProjectReference Include="..\..\src\Tributary.Abstractions\Tributary.Abstractions.csproj" />
         <ProjectReference Include="..\..\src\Tributary.Runtime.Storage.Abstractions\Tributary.Runtime.Storage.Abstractions.csproj" />
+        <ProjectReference Include="..\..\src\Tributary.Runtime.Storage.Blobs\Tributary.Runtime.Storage.Blobs.csproj" />
         <ProjectReference Include="..\..\src\Brooks.Serialization.Abstractions\Brooks.Serialization.Abstractions.csproj" />
         <ProjectReference Include="..\..\src\Brooks.Serialization.Json\Brooks.Serialization.Json.csproj" />
         <ProjectReference Include="..\..\src\Tributary.Runtime.Storage.Cosmos\Tributary.Runtime.Storage.Cosmos.csproj" />

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/Diagnostics/SnapshotBlobStorageMetricsTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/Diagnostics/SnapshotBlobStorageMetricsTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+using Mississippi.Tributary.Runtime.Storage.Blobs.Diagnostics;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests.Diagnostics;
+
+/// <summary>
+///     Tests for Blob snapshot storage metrics.
+/// </summary>
+public sealed class SnapshotBlobStorageMetricsTests
+{
+    private sealed record MetricMeasurement(
+        string InstrumentName,
+        long LongValue,
+        double DoubleValue,
+        IReadOnlyDictionary<string, object?> Tags
+    );
+
+    /// <summary>
+    ///     Verifies delete metrics use the Blob snapshot meter name and expected tags.
+    /// </summary>
+    [Fact]
+    public void RecordDeleteEmitsMetric()
+    {
+        using MeterListener listener = new();
+        List<MetricMeasurement> measurements = [];
+        listener.InstrumentPublished = (
+            instrument,
+            meterListener
+        ) =>
+        {
+            if (instrument.Meter.Name == SnapshotBlobStorageMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            measurements.Add(new(instrument.Name, measurement, 0, tagMap));
+        });
+        listener.Start();
+        SnapshotBlobStorageMetrics.RecordDelete("TestSnapshot");
+        Assert.Contains(
+            measurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.delete.count") &&
+                           (measurement.LongValue == 1) &&
+                           measurement.Tags.TryGetValue("snapshot.type", out object? snapshotType) &&
+                           (snapshotType as string == "TestSnapshot"));
+    }
+
+    /// <summary>
+    ///     Verifies prune metrics are suppressed for non-positive counts.
+    /// </summary>
+    /// <param name="prunedCount">The pruned count to test.</param>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void RecordPruneDoesNotEmitWhenCountIsZeroOrNegative(
+        int prunedCount
+    )
+    {
+        using MeterListener listener = new();
+        List<MetricMeasurement> measurements = [];
+        listener.InstrumentPublished = (
+            instrument,
+            meterListener
+        ) =>
+        {
+            if (instrument.Meter.Name == SnapshotBlobStorageMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            measurements.Add(new(instrument.Name, measurement, 0, tagMap));
+        });
+        listener.Start();
+        SnapshotBlobStorageMetrics.RecordPrune("PruneSnapshot", prunedCount);
+        Assert.DoesNotContain(
+            measurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.prune.count") &&
+                           measurement.Tags.TryGetValue("snapshot.type", out object? snapshotType) &&
+                           (snapshotType as string == "PruneSnapshot"));
+    }
+
+    /// <summary>
+    ///     Verifies positive prune counts emit metrics.
+    /// </summary>
+    [Fact]
+    public void RecordPruneEmitsMetricWhenCountIsPositive()
+    {
+        using MeterListener listener = new();
+        List<MetricMeasurement> measurements = [];
+        listener.InstrumentPublished = (
+            instrument,
+            meterListener
+        ) =>
+        {
+            if (instrument.Meter.Name == SnapshotBlobStorageMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            measurements.Add(new(instrument.Name, measurement, 0, tagMap));
+        });
+        listener.Start();
+        SnapshotBlobStorageMetrics.RecordPrune("PruneSnapshot", 3);
+        Assert.Contains(
+            measurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.prune.count") &&
+                           (measurement.LongValue == 3) &&
+                           measurement.Tags.TryGetValue("snapshot.type", out object? snapshotType) &&
+                           (snapshotType as string == "PruneSnapshot"));
+    }
+
+    /// <summary>
+    ///     Verifies reads emit count and duration metrics.
+    /// </summary>
+    [Fact]
+    public void RecordReadEmitsMetricsWhenFound()
+    {
+        using MeterListener listener = new();
+        List<MetricMeasurement> longMeasurements = [];
+        List<MetricMeasurement> doubleMeasurements = [];
+        listener.InstrumentPublished = (
+            instrument,
+            meterListener
+        ) =>
+        {
+            if (instrument.Meter.Name == SnapshotBlobStorageMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            longMeasurements.Add(new(instrument.Name, measurement, 0, tagMap));
+        });
+        listener.SetMeasurementEventCallback<double>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            doubleMeasurements.Add(new(instrument.Name, 0, measurement, tagMap));
+        });
+        listener.Start();
+        SnapshotBlobStorageMetrics.RecordRead("TestSnapshot", 50.0, true);
+        Assert.Contains(
+            longMeasurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.read.count") &&
+                           (measurement.LongValue == 1) &&
+                           measurement.Tags.TryGetValue("result", out object? result) &&
+                           (result as string == "found"));
+        Assert.Contains(
+            doubleMeasurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.read.duration") &&
+                           (Math.Abs(measurement.DoubleValue - 50.0) < 0.01));
+    }
+
+    /// <summary>
+    ///     Verifies missing reads emit the not-found result tag.
+    /// </summary>
+    [Fact]
+    public void RecordReadEmitsMetricsWhenNotFound()
+    {
+        using MeterListener listener = new();
+        List<MetricMeasurement> measurements = [];
+        listener.InstrumentPublished = (
+            instrument,
+            meterListener
+        ) =>
+        {
+            if (instrument.Meter.Name == SnapshotBlobStorageMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            measurements.Add(new(instrument.Name, measurement, 0, tagMap));
+        });
+        listener.Start();
+        SnapshotBlobStorageMetrics.RecordRead("TestSnapshot", 25.0, false);
+        Assert.Contains(
+            measurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.read.count") &&
+                           (measurement.LongValue == 1) &&
+                           measurement.Tags.TryGetValue("result", out object? result) &&
+                           (result as string == "not_found"));
+    }
+
+    /// <summary>
+    ///     Verifies writes emit count, duration, and size metrics.
+    /// </summary>
+    [Fact]
+    public void RecordWriteEmitsMetricsWithSize()
+    {
+        using MeterListener listener = new();
+        List<MetricMeasurement> longMeasurements = [];
+        List<MetricMeasurement> doubleMeasurements = [];
+        listener.InstrumentPublished = (
+            instrument,
+            meterListener
+        ) =>
+        {
+            if (instrument.Meter.Name == SnapshotBlobStorageMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            longMeasurements.Add(new(instrument.Name, measurement, 0, tagMap));
+        });
+        listener.SetMeasurementEventCallback<double>((
+            instrument,
+            measurement,
+            tags,
+            _
+        ) =>
+        {
+            Dictionary<string, object?> tagMap = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagMap[tag.Key] = tag.Value;
+            }
+
+            doubleMeasurements.Add(new(instrument.Name, 0, measurement, tagMap));
+        });
+        listener.Start();
+        SnapshotBlobStorageMetrics.RecordWrite("TestSnapshot", 100.0, true, 4096L);
+        Assert.Contains(
+            longMeasurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.write.count") &&
+                           (measurement.LongValue == 1) &&
+                           measurement.Tags.TryGetValue("result", out object? result) &&
+                           (result as string == "success"));
+        Assert.Contains(
+            doubleMeasurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.write.duration") &&
+                           (Math.Abs(measurement.DoubleValue - 100.0) < 0.01));
+        Assert.Contains(
+            longMeasurements,
+            measurement => (measurement.InstrumentName == "blob.snapshot.size") && (measurement.LongValue == 4096L));
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobCompressionTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobCompressionTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Text;
+
+using Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests;
+
+/// <summary>
+///     Tests for Blob snapshot compression helpers.
+/// </summary>
+public sealed class SnapshotBlobCompressionTests
+{
+    /// <summary>
+    ///     Verifies disabled compression preserves the original bytes and metadata.
+    /// </summary>
+    [Fact]
+    public void CompressShouldLeavePayloadUnchangedWhenCompressionIsDisabled()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("plain-text-payload");
+        SnapshotBlobCompressionResult result = SnapshotBlobCompression.Compress(payload, false);
+        Assert.Equal(SnapshotBlobCompression.None, result.Compression);
+        Assert.Equal(payload, result.StoredBytes);
+        Assert.Equal(payload.LongLength, result.StoredSizeBytes);
+    }
+
+    /// <summary>
+    ///     Verifies decompression fails closed for unsupported compression metadata.
+    /// </summary>
+    [Fact]
+    public void DecompressShouldThrowWhenCompressionValueIsUnsupported()
+    {
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() => SnapshotBlobCompression.Decompress(
+            "lz4",
+            [1, 2, 3, 4]));
+        Assert.Contains("Unsupported", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Verifies gzip decompression stops before exceeding the configured payload limit.
+    /// </summary>
+    [Fact]
+    public void DecompressShouldThrowWhenPayloadExceedsMaximum()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes(new string('x', 512));
+        SnapshotBlobCompressionResult result = SnapshotBlobCompression.Compress(payload, true);
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() => SnapshotBlobCompression.Decompress(
+            result.Compression,
+            result.StoredBytes,
+            1));
+        Assert.NotNull(exception);
+    }
+
+    /// <summary>
+    ///     Verifies corrupt gzip payloads fail closed.
+    /// </summary>
+    [Fact]
+    public void DecompressShouldThrowWhenPayloadIsCorrupt()
+    {
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() => SnapshotBlobCompression.Decompress(
+            SnapshotBlobCompression.Gzip,
+            [1, 2, 3, 4]));
+        Assert.NotNull(exception);
+    }
+
+    /// <summary>
+    ///     Verifies gzip compression round-trips payload bytes and records stored size before Base64 encoding.
+    /// </summary>
+    [Fact]
+    public void GzipShouldRoundTripPayloadAndRecordStoredSize()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes(new string('x', 512));
+        SnapshotBlobCompressionResult result = SnapshotBlobCompression.Compress(payload, true);
+        byte[] roundTripped = SnapshotBlobCompression.Decompress(result.Compression, result.StoredBytes);
+        Assert.Equal(SnapshotBlobCompression.Gzip, result.Compression);
+        Assert.Equal(payload, roundTripped);
+        Assert.Equal(result.StoredBytes.LongLength, result.StoredSizeBytes);
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobDocumentTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobDocumentTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text.Json;
+
+using Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests;
+
+/// <summary>
+///     Tests for Blob snapshot JSON document serialization.
+/// </summary>
+public sealed class SnapshotBlobDocumentTests
+{
+    /// <summary>
+    ///     Verifies schema v1 serializes the required document properties with the expected names.
+    /// </summary>
+    [Fact]
+    public void SerializeShouldWriteSchemaVersionOneWithRequiredProperties()
+    {
+        string payload = Convert.ToBase64String([1, 2, 3, 4]);
+        SnapshotBlobDocument document = new()
+        {
+            SchemaVersion = SnapshotBlobDocument.CurrentSchemaVersion,
+            BrookName = "TEST.BROOK",
+            SnapshotStorageName = "BankAccountBalance",
+            EntityId = "acct-123",
+            ReducersHash = "reducers-hash",
+            Version = 17,
+            DataContentType = "application/octet-stream",
+            DataSizeBytes = 4,
+            Compression = SnapshotBlobCompression.Gzip,
+            StoredSizeBytes = 4,
+            Data = payload,
+        };
+        BinaryData json = SnapshotBlobDocumentSerializer.Serialize(document);
+        using JsonDocument parsed = JsonDocument.Parse(json.ToString());
+        JsonElement root = parsed.RootElement;
+        Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal("TEST.BROOK", root.GetProperty("brookName").GetString());
+        Assert.Equal("BankAccountBalance", root.GetProperty("snapshotStorageName").GetString());
+        Assert.Equal("acct-123", root.GetProperty("entityId").GetString());
+        Assert.Equal("reducers-hash", root.GetProperty("reducersHash").GetString());
+        Assert.Equal(17, root.GetProperty("version").GetInt64());
+        Assert.Equal("application/octet-stream", root.GetProperty("dataContentType").GetString());
+        Assert.Equal(4, root.GetProperty("dataSizeBytes").GetInt64());
+        Assert.Equal("gzip", root.GetProperty("compression").GetString());
+        Assert.Equal(4, root.GetProperty("storedSizeBytes").GetInt64());
+        Assert.Equal(payload, root.GetProperty("data").GetString());
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobNameTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobNameTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+using Mississippi.Tributary.Abstractions;
+using Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests;
+
+/// <summary>
+///     Tests for Blob snapshot naming and stream prefixes.
+/// </summary>
+public sealed class SnapshotBlobNameTests
+{
+    private static readonly SnapshotStreamKey StreamKey = new(
+        "TEST.BROOK",
+        "BankAccountBalance",
+        "acct/../123 with spaces",
+        "reducers-hash");
+
+    /// <summary>
+    ///     Verifies the durable Blob path format for a concrete snapshot version.
+    /// </summary>
+    [Fact]
+    public void BuildSnapshotBlobNameShouldUseResolvedStoragePath()
+    {
+        SnapshotKey snapshotKey = new(StreamKey, 42);
+        string expectedHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(StreamKey.ToString())));
+        string blobName = SnapshotBlobPath.BuildSnapshotBlobName(snapshotKey);
+        Assert.Equal($"v1/streams/{expectedHash}/versions/00000000000000000042.json", blobName);
+        Assert.DoesNotContain(StreamKey.BrookName, blobName, StringComparison.Ordinal);
+        Assert.DoesNotContain(StreamKey.EntityId, blobName, StringComparison.Ordinal);
+        Assert.DoesNotContain(snapshotKey.ToString(), blobName, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Verifies the stream prefix is derived from the SHA-256 hash of <see cref="SnapshotStreamKey.ToString" />.
+    /// </summary>
+    [Fact]
+    public void BuildStreamPrefixShouldHashSnapshotStreamKeyToString()
+    {
+        string expectedHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(StreamKey.ToString())));
+        string prefix = SnapshotBlobPath.BuildStreamPrefix(StreamKey);
+        Assert.Equal($"v1/streams/{expectedHash}/versions/", prefix);
+        Assert.DoesNotContain(StreamKey.ToString(), prefix, StringComparison.Ordinal);
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobRepositoryTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobRepositoryTests.cs
@@ -1,0 +1,452 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Mississippi.Tributary.Abstractions;
+using Mississippi.Tributary.Runtime.Storage.Blobs.Storage;
+
+using Moq;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests;
+
+/// <summary>
+///     Tests for <see cref="SnapshotBlobRepository" />.
+/// </summary>
+public sealed class SnapshotBlobRepositoryTests
+{
+    private static readonly SnapshotStreamKey StreamKey = new(
+        "TEST.BROOK",
+        "BankAccountBalance",
+        "acct-123",
+        "reducers-hash");
+
+    private static readonly SnapshotKey SnapshotKey = new(StreamKey, 7);
+
+    private static SnapshotBlobDocument CreateDocument(
+        byte[] payload,
+        int schemaVersion = SnapshotBlobDocument.CurrentSchemaVersion,
+        string? entityId = null,
+        string? compressionValue = null,
+        long? dataSizeBytes = null,
+        long? storedSizeBytes = null,
+        bool enableCompression = false
+    )
+    {
+        SnapshotBlobCompressionResult compression = SnapshotBlobCompression.Compress(payload, enableCompression);
+        return new()
+        {
+            SchemaVersion = schemaVersion,
+            BrookName = SnapshotKey.Stream.BrookName,
+            SnapshotStorageName = SnapshotKey.Stream.SnapshotStorageName,
+            EntityId = entityId ?? SnapshotKey.Stream.EntityId,
+            ReducersHash = SnapshotKey.Stream.ReducersHash,
+            Version = SnapshotKey.Version,
+            DataContentType = "application/x-test",
+            DataSizeBytes = dataSizeBytes ?? payload.LongLength,
+            Compression = compressionValue ?? compression.Compression,
+            StoredSizeBytes = storedSizeBytes ?? compression.StoredSizeBytes,
+            Data = Convert.ToBase64String(compression.StoredBytes),
+        };
+    }
+
+    private static SnapshotBlobRepository CreateRepository(
+        Mock<ISnapshotBlobOperations> operations,
+        Action<SnapshotBlobStorageOptions>? configure = null
+    )
+    {
+        SnapshotBlobStorageOptions options = new();
+        configure?.Invoke(options);
+        return new(operations.Object, Options.Create(options), NullLogger<SnapshotBlobRepository>.Instance);
+    }
+
+    private static void SetupDownload(
+        Mock<ISnapshotBlobOperations> operations,
+        SnapshotBlobDocument document
+    ) =>
+        operations.Setup(o => o.DownloadAsync(
+                SnapshotBlobPath.BuildSnapshotBlobName(SnapshotKey),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SnapshotBlobDocumentSerializer.Serialize(document));
+
+    private static async IAsyncEnumerable<string> ToAsyncEnumerableAsync(
+        IEnumerable<string> items,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        foreach (string item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    ///     Verifies delete-all only removes well-formed snapshot version blobs for the requested stream prefix.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllAsyncShouldDeleteOnlyMatchingSnapshotBlobsForStream()
+    {
+        string prefix = SnapshotBlobPath.BuildStreamPrefix(StreamKey);
+        List<string> deleted = [];
+        Mock<ISnapshotBlobOperations> operations = new();
+        operations.Setup(o => o.ListBlobNamesAsync(prefix, It.IsAny<CancellationToken>()))
+            .Returns(
+                ToAsyncEnumerableAsync(
+                [
+                    SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 1)),
+                    $"{prefix}notes.txt",
+                    SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 2)),
+                ]));
+        operations.Setup(o => o.DeleteIfExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((
+                blobName,
+                _
+            ) => deleted.Add(blobName))
+            .ReturnsAsync(true);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await repository.DeleteAllAsync(StreamKey, CancellationToken.None);
+        Assert.Equal(
+            [
+                SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 1)),
+                SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 2)),
+            ],
+            deleted);
+    }
+
+    /// <summary>
+    ///     Verifies deleting a specific snapshot uses the expected hashed Blob path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAsyncShouldCallDeleteOnExpectedBlobName()
+    {
+        Mock<ISnapshotBlobOperations> operations = new();
+        operations.Setup(o => o.DeleteIfExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await repository.DeleteAsync(SnapshotKey, CancellationToken.None);
+        operations.Verify(
+            o => o.DeleteIfExistsAsync(
+                SnapshotBlobPath.BuildSnapshotBlobName(SnapshotKey),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    ///     Verifies prune always retains the highest version and versions matching retention moduli.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PruneAsyncShouldRetainMaxVersionAndMatchingModuli()
+    {
+        string prefix = SnapshotBlobPath.BuildStreamPrefix(StreamKey);
+        List<string> deleted = [];
+        Mock<ISnapshotBlobOperations> operations = new();
+        operations.Setup(o => o.ListBlobNamesAsync(prefix, It.IsAny<CancellationToken>()))
+            .Returns(
+                ToAsyncEnumerableAsync(
+                [
+                    SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 1)),
+                    SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 2)),
+                    SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 3)),
+                    SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 4)),
+                    SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 5)),
+                    $"{prefix}not-a-version.json",
+                ]));
+        operations.Setup(o => o.DeleteIfExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((
+                blobName,
+                _
+            ) => deleted.Add(blobName))
+            .ReturnsAsync(true);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        int deletedCount = await repository.PruneAsync(StreamKey, [2], CancellationToken.None);
+        Assert.Equal(2, deletedCount);
+        Assert.Equal(
+            [
+                SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 1)),
+                SnapshotBlobPath.BuildSnapshotBlobName(new(StreamKey, 3)),
+            ],
+            deleted);
+    }
+
+    /// <summary>
+    ///     Verifies reads preserve all envelope metadata, including reducer hash.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldReturnEnvelopeWithAllMetadata()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("compressed snapshot payload");
+        SnapshotBlobCompressionResult compression = SnapshotBlobCompression.Compress(payload, true);
+        SnapshotBlobDocument document = new()
+        {
+            SchemaVersion = SnapshotBlobDocument.CurrentSchemaVersion,
+            BrookName = SnapshotKey.Stream.BrookName,
+            SnapshotStorageName = SnapshotKey.Stream.SnapshotStorageName,
+            EntityId = SnapshotKey.Stream.EntityId,
+            ReducersHash = SnapshotKey.Stream.ReducersHash,
+            Version = SnapshotKey.Version,
+            DataContentType = "application/x-test",
+            DataSizeBytes = payload.LongLength,
+            Compression = compression.Compression,
+            StoredSizeBytes = compression.StoredSizeBytes,
+            Data = Convert.ToBase64String(compression.StoredBytes),
+        };
+        Mock<ISnapshotBlobOperations> operations = new();
+        operations.Setup(o => o.DownloadAsync(
+                SnapshotBlobPath.BuildSnapshotBlobName(SnapshotKey),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SnapshotBlobDocumentSerializer.Serialize(document));
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        SnapshotEnvelope? result = await repository.ReadAsync(SnapshotKey, CancellationToken.None);
+        Assert.NotNull(result);
+        Assert.Equal(payload, result!.Data.AsSpan().ToArray());
+        Assert.Equal("application/x-test", result.DataContentType);
+        Assert.Equal(payload.LongLength, result.DataSizeBytes);
+        Assert.Equal(SnapshotKey.Stream.ReducersHash, result.ReducerHash);
+    }
+
+    /// <summary>
+    ///     Verifies a missing Blob document returns <c>null</c>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldReturnNullWhenBlobIsMissing()
+    {
+        Mock<ISnapshotBlobOperations> operations = new();
+        operations.Setup(o => o.DownloadAsync(
+                SnapshotBlobPath.BuildSnapshotBlobName(SnapshotKey),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BinaryData?)null);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        SnapshotEnvelope? result = await repository.ReadAsync(SnapshotKey, CancellationToken.None);
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    ///     Verifies reads reject documents with mismatched uncompressed payload sizes.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldThrowWhenDataSizeDoesNotMatchDocument()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotBlobDocument document = CreateDocument(payload, dataSizeBytes: payload.LongLength + 1);
+        Mock<ISnapshotBlobOperations> operations = new();
+        SetupDownload(operations, document);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await Assert.ThrowsAsync<InvalidDataException>(() => repository.ReadAsync(SnapshotKey, CancellationToken.None));
+    }
+
+    /// <summary>
+    ///     Verifies reads reject documents whose declared uncompressed size exceeds the configured limit.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldThrowWhenDeclaredPayloadSizeExceedsConfiguredMaximum()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotBlobDocument document = CreateDocument(payload, dataSizeBytes: 2);
+        Mock<ISnapshotBlobOperations> operations = new();
+        SetupDownload(operations, document);
+        SnapshotBlobRepository repository = CreateRepository(
+            operations,
+            options => options.MaximumSnapshotPayloadSizeBytes = 1);
+        await Assert.ThrowsAsync<InvalidDataException>(() => repository.ReadAsync(SnapshotKey, CancellationToken.None));
+    }
+
+    /// <summary>
+    ///     Verifies reads reject documents with unsupported compression values.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldThrowWhenDocumentCompressionIsUnsupported()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotBlobDocument document = CreateDocument(payload, compressionValue: "lz4");
+        Mock<ISnapshotBlobOperations> operations = new();
+        SetupDownload(operations, document);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await Assert.ThrowsAsync<InvalidDataException>(() => repository.ReadAsync(SnapshotKey, CancellationToken.None));
+    }
+
+    /// <summary>
+    ///     Verifies reads reject documents whose key fields do not match the requested snapshot key.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldThrowWhenDocumentDoesNotMatchRequestedKey()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotBlobDocument document = CreateDocument(payload, entityId: "other-account");
+        Mock<ISnapshotBlobOperations> operations = new();
+        SetupDownload(operations, document);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await Assert.ThrowsAsync<InvalidDataException>(() => repository.ReadAsync(SnapshotKey, CancellationToken.None));
+    }
+
+    /// <summary>
+    ///     Verifies reads reject documents with unsupported schema versions.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldThrowWhenDocumentSchemaVersionIsUnsupported()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotBlobDocument document = CreateDocument(payload, SnapshotBlobDocument.CurrentSchemaVersion + 1);
+        Mock<ISnapshotBlobOperations> operations = new();
+        SetupDownload(operations, document);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await Assert.ThrowsAsync<InvalidDataException>(() => repository.ReadAsync(SnapshotKey, CancellationToken.None));
+    }
+
+    /// <summary>
+    ///     Verifies reads reject documents whose stored payload size metadata does not match the encoded bytes.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldThrowWhenStoredSizeDoesNotMatchDocument()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotBlobDocument document = CreateDocument(payload, storedSizeBytes: payload.LongLength + 1);
+        Mock<ISnapshotBlobOperations> operations = new();
+        SetupDownload(operations, document);
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await Assert.ThrowsAsync<InvalidDataException>(() => repository.ReadAsync(SnapshotKey, CancellationToken.None));
+    }
+
+    /// <summary>
+    ///     Verifies writes reject envelopes whose declared size does not match the payload length.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task WriteAsyncShouldThrowWhenDataSizeBytesDoesNotMatchPayloadLength()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotEnvelope envelope = new()
+        {
+            Data = ImmutableArray.Create(payload),
+            DataContentType = "application/x-test",
+            DataSizeBytes = payload.LongLength + 1,
+            ReducerHash = SnapshotKey.Stream.ReducersHash,
+        };
+        Mock<ISnapshotBlobOperations> operations = new();
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await Assert.ThrowsAsync<ArgumentException>(() => repository.WriteAsync(
+            SnapshotKey,
+            envelope,
+            CancellationToken.None));
+        operations.Verify(
+            o => o.UploadAsync(It.IsAny<string>(), It.IsAny<BinaryData>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    ///     Verifies writes reject envelopes whose payload exceeds the configured maximum size.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task WriteAsyncShouldThrowWhenPayloadExceedsConfiguredMaximum()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotEnvelope envelope = new()
+        {
+            Data = ImmutableArray.Create(payload),
+            DataContentType = "application/x-test",
+            DataSizeBytes = payload.LongLength,
+            ReducerHash = SnapshotKey.Stream.ReducersHash,
+        };
+        Mock<ISnapshotBlobOperations> operations = new();
+        SnapshotBlobRepository repository = CreateRepository(
+            operations,
+            options => options.MaximumSnapshotPayloadSizeBytes = payload.LongLength - 1);
+        await Assert.ThrowsAsync<ArgumentException>(() => repository.WriteAsync(
+            SnapshotKey,
+            envelope,
+            CancellationToken.None));
+        operations.Verify(
+            o => o.UploadAsync(It.IsAny<string>(), It.IsAny<BinaryData>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    ///     Verifies writes reject envelopes whose reducer hash does not match the snapshot key stream.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task WriteAsyncShouldThrowWhenReducerHashDoesNotMatchSnapshotKey()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("payload");
+        SnapshotEnvelope envelope = new()
+        {
+            Data = ImmutableArray.Create(payload),
+            DataContentType = "application/x-test",
+            DataSizeBytes = payload.LongLength,
+            ReducerHash = "different-reducers-hash",
+        };
+        Mock<ISnapshotBlobOperations> operations = new();
+        SnapshotBlobRepository repository = CreateRepository(operations);
+        await Assert.ThrowsAsync<ArgumentException>(() => repository.WriteAsync(
+            SnapshotKey,
+            envelope,
+            CancellationToken.None));
+        operations.Verify(
+            o => o.UploadAsync(It.IsAny<string>(), It.IsAny<BinaryData>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    ///     Verifies writes upload a JSON document to the expected hashed Blob path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task WriteAsyncShouldUploadDocumentToExpectedBlobName()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes(new string('x', 256));
+        SnapshotEnvelope envelope = new()
+        {
+            Data = ImmutableArray.Create(payload),
+            DataContentType = "application/x-test",
+            DataSizeBytes = payload.LongLength,
+            ReducerHash = SnapshotKey.Stream.ReducersHash,
+        };
+        string? uploadedBlobName = null;
+        BinaryData? uploadedDocument = null;
+        Mock<ISnapshotBlobOperations> operations = new();
+        operations.Setup(o => o.UploadAsync(It.IsAny<string>(), It.IsAny<BinaryData>(), It.IsAny<CancellationToken>()))
+            .Callback<string, BinaryData, CancellationToken>((
+                blobName,
+                document,
+                _
+            ) =>
+            {
+                uploadedBlobName = blobName;
+                uploadedDocument = document;
+            })
+            .Returns(Task.CompletedTask);
+        SnapshotBlobRepository repository = CreateRepository(operations, options => options.EnableCompression = true);
+        await repository.WriteAsync(SnapshotKey, envelope, CancellationToken.None);
+        Assert.Equal(SnapshotBlobPath.BuildSnapshotBlobName(SnapshotKey), uploadedBlobName);
+        Assert.NotNull(uploadedDocument);
+        SnapshotBlobDocument document = SnapshotBlobDocumentSerializer.Deserialize(uploadedDocument!);
+        Assert.Equal(SnapshotBlobCompression.Gzip, document.Compression);
+        Assert.Equal(payload.LongLength, document.DataSizeBytes);
+        Assert.Equal("application/x-test", document.DataContentType);
+        Assert.Equal(SnapshotKey.Stream.ReducersHash, document.ReducersHash);
+        Assert.Equal(SnapshotKey.Stream.SnapshotStorageName, document.SnapshotStorageName);
+        Assert.Equal(SnapshotKey.Version, document.Version);
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageOptionsTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageOptionsTests.cs
@@ -1,0 +1,119 @@
+using System;
+
+using Microsoft.Extensions.Options;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests;
+
+/// <summary>
+///     Tests for <see cref="SnapshotBlobStorageOptions" /> and <see cref="SnapshotBlobDefaults" />.
+/// </summary>
+public sealed class SnapshotBlobStorageOptionsTests
+{
+    /// <summary>
+    ///     Verifies the default Blob container name.
+    /// </summary>
+    [Fact]
+    public void ContainerNameShouldReturnDefaultValue()
+    {
+        SnapshotBlobStorageOptions options = new();
+        Assert.Equal(SnapshotBlobDefaults.ContainerName, options.ContainerName);
+    }
+
+    /// <summary>
+    ///     Verifies compression defaults to disabled.
+    /// </summary>
+    [Fact]
+    public void EnableCompressionShouldDefaultToFalse()
+    {
+        SnapshotBlobStorageOptions options = new();
+        Assert.False(options.EnableCompression);
+    }
+
+    /// <summary>
+    ///     Verifies the default uncompressed payload size limit.
+    /// </summary>
+    [Fact]
+    public void MaximumSnapshotPayloadSizeBytesShouldReturnDefaultValue()
+    {
+        SnapshotBlobStorageOptions options = new();
+        Assert.Equal(
+            SnapshotBlobDefaults.DefaultMaximumSnapshotPayloadSizeBytes,
+            options.MaximumSnapshotPayloadSizeBytes);
+    }
+
+    /// <summary>
+    ///     Verifies public defaults retain the expected contract values.
+    /// </summary>
+    [Fact]
+    public void SnapshotBlobDefaultsShouldMatchExpectedContractValues()
+    {
+        Assert.Equal("snapshots", SnapshotBlobDefaults.ContainerName);
+        Assert.Equal("mississippi-blob-snapshots", SnapshotBlobDefaults.BlobServiceClientServiceKey);
+        Assert.Equal("mississippi-blob-snapshots-container", SnapshotBlobDefaults.BlobContainerClientServiceKey);
+        Assert.Equal(134217728L, SnapshotBlobDefaults.DefaultMaximumSnapshotPayloadSizeBytes);
+    }
+
+    /// <summary>
+    ///     Verifies options validation accepts valid default options.
+    /// </summary>
+    [Fact]
+    public void ValidatorShouldAcceptValidOptions()
+    {
+        SnapshotBlobStorageOptionsValidator validator = new();
+        ValidateOptionsResult result = validator.Validate(Options.DefaultName, new());
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>
+    ///     Verifies options validation rejects a blank Blob service client key.
+    /// </summary>
+    [Fact]
+    public void ValidatorShouldRejectBlankBlobServiceClientServiceKey()
+    {
+        SnapshotBlobStorageOptions options = new()
+        {
+            BlobServiceClientServiceKey = " ",
+        };
+        SnapshotBlobStorageOptionsValidator validator = new();
+        ValidateOptionsResult result = validator.Validate(Options.DefaultName, options);
+        Assert.True(result.Failed);
+        Assert.Contains(
+            result.Failures,
+            failure => failure.Contains("BlobServiceClientServiceKey", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Verifies options validation rejects an invalid container name.
+    /// </summary>
+    [Fact]
+    public void ValidatorShouldRejectInvalidContainerName()
+    {
+        SnapshotBlobStorageOptions options = new()
+        {
+            ContainerName = "INVALID_CONTAINER",
+        };
+        SnapshotBlobStorageOptionsValidator validator = new();
+        ValidateOptionsResult result = validator.Validate(Options.DefaultName, options);
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, failure => failure.Contains("ContainerName", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Verifies options validation rejects non-positive payload size limits.
+    /// </summary>
+    [Fact]
+    public void ValidatorShouldRejectNonPositivePayloadSizeLimit()
+    {
+        SnapshotBlobStorageOptions options = new()
+        {
+            MaximumSnapshotPayloadSizeBytes = 0,
+        };
+        SnapshotBlobStorageOptionsValidator validator = new();
+        ValidateOptionsResult result = validator.Validate(Options.DefaultName, options);
+        Assert.True(result.Failed);
+        Assert.Contains(
+            result.Failures,
+            failure => failure.Contains("MaximumSnapshotPayloadSizeBytes", StringComparison.Ordinal));
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageProviderRegistrationsTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageProviderRegistrationsTests.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Azure.Storage.Blobs;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Mississippi.Tributary.Runtime.Storage.Abstractions;
+
+using Moq;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests;
+
+/// <summary>
+///     Tests for Blob snapshot storage DI registrations.
+/// </summary>
+public sealed class SnapshotBlobStorageProviderRegistrationsTests
+{
+    private static BlobServiceClient CreateBlobServiceClient() => new("UseDevelopmentStorage=true");
+
+    /// <summary>
+    ///     Verifies the hosted initializer is registered with DI.
+    /// </summary>
+    [Fact]
+    public void AddBlobSnapshotStorageProviderShouldRegisterHostedInitializer()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddKeyedSingleton<BlobServiceClient>(
+            SnapshotBlobDefaults.BlobServiceClientServiceKey,
+            CreateBlobServiceClient());
+        services.AddBlobSnapshotStorageProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IReadOnlyList<IHostedService> hostedServices = provider.GetServices<IHostedService>().ToList();
+        Assert.Contains(hostedServices, hostedService => hostedService is SnapshotBlobContainerInitializer);
+    }
+
+    /// <summary>
+    ///     Verifies the main registration method wires provider services and the keyed container client.
+    /// </summary>
+    [Fact]
+    public void AddBlobSnapshotStorageProviderShouldRegisterServices()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddKeyedSingleton<BlobServiceClient>(
+            SnapshotBlobDefaults.BlobServiceClientServiceKey,
+            CreateBlobServiceClient());
+        services.AddBlobSnapshotStorageProvider(options => options.ContainerName = "snapshots-test");
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetRequiredService<ISnapshotBlobOperations>());
+        Assert.NotNull(provider.GetRequiredService<ISnapshotBlobRepository>());
+        Assert.NotNull(provider.GetRequiredService<ISnapshotStorageProvider>());
+        Assert.NotNull(provider.GetRequiredService<ISnapshotStorageReader>());
+        Assert.NotNull(provider.GetRequiredService<ISnapshotStorageWriter>());
+        Assert.NotNull(provider.GetRequiredService<IValidateOptions<SnapshotBlobStorageOptions>>());
+        BlobContainerClient containerClient =
+            provider.GetRequiredKeyedService<BlobContainerClient>(SnapshotBlobDefaults.BlobContainerClientServiceKey);
+        Assert.Equal("snapshots-test", containerClient.Name);
+    }
+
+    /// <summary>
+    ///     Verifies the configuration overload binds options from configuration.
+    /// </summary>
+    [Fact]
+    public void AddBlobSnapshotStorageProviderWithConfigurationShouldBindOptions()
+    {
+        IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["ContainerName"] = "configured-snapshots",
+                    ["EnableCompression"] = "true",
+                })
+            .Build();
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddKeyedSingleton<BlobServiceClient>(
+            SnapshotBlobDefaults.BlobServiceClientServiceKey,
+            CreateBlobServiceClient());
+        services.AddBlobSnapshotStorageProvider(configuration);
+        using ServiceProvider provider = services.BuildServiceProvider();
+        SnapshotBlobStorageOptions options = provider.GetRequiredService<IOptions<SnapshotBlobStorageOptions>>().Value;
+        Assert.Equal("configured-snapshots", options.ContainerName);
+        Assert.True(options.EnableCompression);
+    }
+
+    /// <summary>
+    ///     Verifies the connection-string overload registers the keyed Blob service client.
+    /// </summary>
+    [Fact]
+    public void AddBlobSnapshotStorageProviderWithConnectionStringShouldRegisterBlobServiceClient()
+    {
+        ServiceCollection services = new();
+        services.AddBlobSnapshotStorageProvider(
+            "UseDevelopmentStorage=true",
+            options => options.ContainerName = "connection-string-snapshots");
+        using ServiceProvider provider = services.BuildServiceProvider();
+        SnapshotBlobStorageOptions options = provider.GetRequiredService<IOptions<SnapshotBlobStorageOptions>>().Value;
+        BlobServiceClient blobServiceClient =
+            provider.GetRequiredKeyedService<BlobServiceClient>(SnapshotBlobDefaults.BlobServiceClientServiceKey);
+        Assert.NotNull(blobServiceClient);
+        Assert.Equal("connection-string-snapshots", options.ContainerName);
+    }
+
+    /// <summary>
+    ///     Verifies the hosted initializer creates the container on host start.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task SnapshotBlobContainerInitializerShouldCreateContainerOnStart()
+    {
+        Mock<ISnapshotBlobOperations> operations = new();
+        operations.Setup(o => o.CreateContainerIfNotExistsAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        SnapshotBlobContainerInitializer initializer = new(
+            operations.Object,
+            NullLogger<SnapshotBlobContainerInitializer>.Instance);
+        await initializer.StartAsync(CancellationToken.None);
+        operations.Verify(o => o.CreateContainerIfNotExistsAsync(CancellationToken.None), Times.Once);
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageProviderTests.cs
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageProviderTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Mississippi.Tributary.Abstractions;
+
+using Moq;
+
+
+namespace Mississippi.Tributary.Runtime.Storage.Blobs.L0Tests;
+
+/// <summary>
+///     Tests for <see cref="SnapshotBlobStorageProvider" />.
+/// </summary>
+public sealed class SnapshotBlobStorageProviderTests
+{
+    private static readonly SnapshotStreamKey StreamKey = new(
+        "TEST.BROOK",
+        "BankAccountBalance",
+        "acct-123",
+        "reducers-hash");
+
+    private static readonly SnapshotKey SnapshotKey = new(StreamKey, 5);
+
+    /// <summary>
+    ///     Verifies constructor argument validation.
+    /// </summary>
+    [Fact]
+    public void ConstructorShouldThrowWhenRepositoryIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SnapshotBlobStorageProvider(
+            null!,
+            NullLogger<SnapshotBlobStorageProvider>.Instance));
+    }
+
+    /// <summary>
+    ///     Verifies delete-all delegates to the repository.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllAsyncShouldDelegate()
+    {
+        Mock<ISnapshotBlobRepository> repository = new();
+        SnapshotBlobStorageProvider provider = new(repository.Object, NullLogger<SnapshotBlobStorageProvider>.Instance);
+        await provider.DeleteAllAsync(StreamKey, CancellationToken.None);
+        repository.Verify(r => r.DeleteAllAsync(StreamKey, CancellationToken.None), Times.Once);
+    }
+
+    /// <summary>
+    ///     Verifies delete delegates to the repository.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAsyncShouldDelegate()
+    {
+        Mock<ISnapshotBlobRepository> repository = new();
+        SnapshotBlobStorageProvider provider = new(repository.Object, NullLogger<SnapshotBlobStorageProvider>.Instance);
+        await provider.DeleteAsync(SnapshotKey, CancellationToken.None);
+        repository.Verify(r => r.DeleteAsync(SnapshotKey, CancellationToken.None), Times.Once);
+    }
+
+    /// <summary>
+    ///     Verifies the provider format identifier is stable.
+    /// </summary>
+    [Fact]
+    public void FormatShouldReturnAzureBlob()
+    {
+        SnapshotBlobStorageProvider provider = new(
+            Mock.Of<ISnapshotBlobRepository>(),
+            NullLogger<SnapshotBlobStorageProvider>.Instance);
+        Assert.Equal("azure-blob", provider.Format);
+    }
+
+    /// <summary>
+    ///     Verifies prune validates arguments and delegates to the repository.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PruneAsyncShouldDelegate()
+    {
+        List<int> retainModuli =
+        [
+            2,
+        ];
+        Mock<ISnapshotBlobRepository> repository = new();
+        repository.Setup(r => r.PruneAsync(StreamKey, retainModuli, CancellationToken.None)).ReturnsAsync(0);
+        SnapshotBlobStorageProvider provider = new(repository.Object, NullLogger<SnapshotBlobStorageProvider>.Instance);
+        await provider.PruneAsync(StreamKey, retainModuli, CancellationToken.None);
+        repository.Verify(r => r.PruneAsync(StreamKey, retainModuli, CancellationToken.None), Times.Once);
+    }
+
+    /// <summary>
+    ///     Verifies prune rejects null retain sets.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PruneAsyncShouldThrowWhenRetainModuliNull()
+    {
+        SnapshotBlobStorageProvider provider = new(
+            Mock.Of<ISnapshotBlobRepository>(),
+            NullLogger<SnapshotBlobStorageProvider>.Instance);
+        await Assert.ThrowsAsync<ArgumentNullException>(() => provider.PruneAsync(
+            StreamKey,
+            null!,
+            CancellationToken.None));
+    }
+
+    /// <summary>
+    ///     Verifies read delegates to the repository.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ReadAsyncShouldDelegate()
+    {
+        SnapshotEnvelope envelope = new();
+        Mock<ISnapshotBlobRepository> repository = new();
+        repository.Setup(r => r.ReadAsync(SnapshotKey, CancellationToken.None)).ReturnsAsync(envelope);
+        SnapshotBlobStorageProvider provider = new(repository.Object, NullLogger<SnapshotBlobStorageProvider>.Instance);
+        SnapshotEnvelope? result = await provider.ReadAsync(SnapshotKey, CancellationToken.None);
+        Assert.Same(envelope, result);
+        repository.Verify(r => r.ReadAsync(SnapshotKey, CancellationToken.None), Times.Once);
+    }
+
+    /// <summary>
+    ///     Verifies write delegates to the repository.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task WriteAsyncShouldDelegate()
+    {
+        SnapshotEnvelope envelope = new();
+        Mock<ISnapshotBlobRepository> repository = new();
+        SnapshotBlobStorageProvider provider = new(repository.Object, NullLogger<SnapshotBlobStorageProvider>.Instance);
+        await provider.WriteAsync(SnapshotKey, envelope, CancellationToken.None);
+        repository.Verify(r => r.WriteAsync(SnapshotKey, envelope, CancellationToken.None), Times.Once);
+    }
+}

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/Tributary.Runtime.Storage.Blobs.L0Tests.csproj
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/Tributary.Runtime.Storage.Blobs.L0Tests.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tributary.Runtime.Storage.Blobs\Tributary.Runtime.Storage.Blobs.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Tributary.Runtime.Storage.Blobs.L0Tests/packages.lock.json
+++ b/tests/Tributary.Runtime.Storage.Blobs.L0Tests/packages.lock.json
@@ -57,16 +57,6 @@
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
       },
-      "TngTech.ArchUnitNET.xUnit": {
-        "type": "Direct",
-        "requested": "[0.13.3, )",
-        "resolved": "0.13.3",
-        "contentHash": "rwgQ9L+/BNGI5kuWozB8uNptXlEYjY38P6jQT388Zat1ZymEuJe8Q097Rrabv28dY0kbNNJVKve9jp7xq9PaOg==",
-        "dependencies": {
-          "TngTech.ArchUnitNET": "0.13.3",
-          "xunit.assert": "2.4.1"
-        }
-      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -111,114 +101,23 @@
           "System.Diagnostics.EventLog": "6.0.0"
         }
       },
-      "CycleDetection": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "iQb2Nm9WqPseGCxPcdeU5qMbWkxtSr1bmnliC7slitx7GOG8cKO2pKZUQ2Yl+DQQZQ7c8qIXe3k+zYE0f96dIA=="
-      },
       "Humanizer.Core": {
         "type": "Transitive",
         "resolved": "2.14.1",
         "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
       },
-      "JetBrains.Annotations": {
-        "type": "Transitive",
-        "resolved": "2025.2.2",
-        "contentHash": "0X56ZRizuHdrnPpgXjWV7f2tQO1FlQg5O1967OGKnI/4ZRNOK642J8L7brM1nYvrxTTU5TP1yRyXLRLaXLPQ8A=="
-      },
-      "Microsoft.AspNetCore.Authorization": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "t+q60N2/+UIBnkuLRJWv1r02fhuwPI1fqUh0xnuWIjsVsU1szYcic0/LW+BcZ4ZaO3mMVVJP3H/F9bwfJgGboA==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Metadata": "10.0.8",
-          "Microsoft.Extensions.Diagnostics": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.Components.Analyzers": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "2bQ1wHeawWxqTlxHdSVAmPZxe6ZBElj4TdvzkTV4ji28kvCHurL0CWTdlFh+q1650hXkm9Zb1nz5AKt/xitaUw=="
-      },
-      "Microsoft.AspNetCore.Components.Forms": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "vgvzcw0YdXTA3rynequip502h34cqEfucQEBJCbzLlkoM8tEYWh7635AKmXz8HFZh/JnwFbR5m1Awm/U4fn7ag==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Components": "10.0.8",
-          "Microsoft.Extensions.Validation": "10.0.8"
-        }
-      },
       "Microsoft.AspNetCore.Connections.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "DfmEvnTPOVfkz8s4zDdmjy7z1iiwid3IDnonPD2V48j812njrfgP7CxphDn0b+Iq92+PU0WFH1xpAv09pTUEvg==",
+        "resolved": "10.0.3",
+        "contentHash": "i016BNW1Yqd5r+lfgWb4BiPjMuCXn+HXYgdbAPLZRkoNw9SSRP58/8AkdPOsWEXRL5BVNJ066CO60HFP99s6QQ==",
         "dependencies": {
-          "Microsoft.Extensions.Features": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Connections.Client": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "qZaRK0U6mL990BlSpLkKnA9O1NQX+5pz9l6/PQIQCHZEpCCuLG2xsBVGOj6YhH5mGe/3GzKvDQfAZt+Iihlqfw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Connections.Common": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Connections.Common": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "gcVqAq9lnp6o+RFmOw/fPlOWQWm8pmB92f59hmF+grZjtByVAx9HeVLE7QJjjPJMt/vubP2TbhXIb0ksxD8cZw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.Metadata": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "N+d8MnpnEhKnbkCZzrV5jyPLpMOA9eSxP91We8B8QRSlt5NnyWDk1deEn8JpErDbyiQBAwhbvkxLofIOijRwTw=="
-      },
-      "Microsoft.AspNetCore.SignalR.Client.Core": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "M4eBfXAdDS8ziiIKGCon+dQZC0u+BIZ1K0JqI982vfNCcr1ZxChp68pDBCShTv4m1D3qJr8YC4Sm4KEWtQ+HRg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.SignalR.Common": "10.0.8",
-          "Microsoft.AspNetCore.SignalR.Protocols.Json": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Common": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "k++Zhl06barMW30QwGoOMNhPOjANk/w8m2Kbz4JNZ6qHQm4jC7yckZqbK8oOyGV6uushrGtpbNTlCpsOWfnFug==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.Json": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "xaN3NF3Kf252nNiY3aq+oRtDM4XayUB8+ZyqR8qHq5InjLxGk7JZPEnN0KIbp6OLeuEAv8s1NwXSsgOSYm3ZVQ==",
-        "dependencies": {
-          "Microsoft.AspNetCore.SignalR.Common": "10.0.8"
+          "Microsoft.Extensions.Features": "10.0.3"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "10.0.2",
         "contentHash": "qE5JhRoeJbAipLqpUCZyNfNwnpAvUttXgIQDnTiJ15d8ji+/bPgoPkB3xLzK5cQTobN2D2ditUesUlDHb7p3Pg=="
-      },
-      "Microsoft.Bcl.HashCode": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "J2G1k+u5unBV+aYcwxo94ip16Rkp65pgWFb0R6zwJipzWNMgvqlWeuI7/+R+e8bob66LnSG+llLJ+z8wI94cHg=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -259,25 +158,25 @@
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "1g9mzuu8gIHkjYb0jLxOTQVl/QDG5nn0b0JzgT/gbgNKr6gXZzxOHRAsdYRc1eDApB7LdHR8uK5vQrNjIQdRrQ==",
+        "resolved": "10.0.3",
+        "contentHash": "/MLsBbLpwDxsU+7DDNwasf2mKrpMSOWEL377gNZTy5waFkCYvS3GVaLIz6bvikH4rAwHrCOxHw0t/5iCoImYCA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "KLtAZ6A38s1pIfCO2ns6aG14NNGMYNZ4PBYfFK4M+R4A+xuSc6oklhqDcpHZxvDpyBWeFtR5C8iQBw2ng8tUHQ==",
+        "resolved": "10.0.3",
+        "contentHash": "mGGMOA9nkET8OVsQfS41o66eWkckBzNHJK6+5VbLQ2YdyqKphcv27uDZxLf4exSl+5QxLnHkN+W/4qEDgyvCPA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
@@ -298,12 +197,12 @@
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "uduyw9d3Fi+sbredO5drA1S44AQS2FRNFyn72UmB2vmQIO1qaXprpp1U/2lYhYi8yFdVERfY9sy/pxw/qPOU9w==",
+        "resolved": "10.0.3",
+        "contentHash": "tc0R6i2T+138taoxFPQXb7Sy/4rtq4ytoJrAt4fNGs6k89mHpEhZnXUNgaFKwwb5Ud5rIUeLC6tfpsuHNwiWqg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
@@ -325,18 +224,18 @@
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "GkPvQe6IdidLu6Q3Lw6+B8NJpW8feW8czZ5mBKt5rXM/x8MvZfEp5WvAsjznzDGd23chIDrW0b2mmt+ScnEgiw==",
+        "resolved": "10.0.3",
+        "contentHash": "8qLl5LXtcj6Z8yPbHAA/a57fvvl9nUCdi59AJFuixcWM4wSuENZ8jjoRATOKs/I4vOi/bDe0d5LqGSSLE634eA==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
+        "resolved": "10.0.3",
+        "contentHash": "oM7pl8uJz8WRPRlh4AGQS61aeV9GOfTu89yqTiRSYyyMuCNVkbNra9zEk7ApyJ/sZrUpbjOZCRHuitCEsTWghg=="
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
@@ -408,28 +307,6 @@
         "type": "Transitive",
         "resolved": "10.0.8",
         "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
-      },
-      "Microsoft.Extensions.Validation": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "CekWvF0+2NUol7aixnG/o7Iy2VCwN6Y3UcTmsDx++oiJlJ6M0ppfymwJ58yANRXRElN3WkHUynIeb+FuNE/3Ww==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
-        }
-      },
-      "Microsoft.JSInterop": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "eGKB3++3SDqRY86Y5prnI0bSceM5dJR03agFPQR8j9eL61HhBYzn3DLt3pVWJAS3t98hwJWuJA+NxB7Q8d4UJA=="
-      },
-      "Microsoft.JSInterop.WebAssembly": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "sXmjUtF9Kb7heF2cDuT1X8wdJQnyXXJ5wMVN52AtBKUDOzMCfSNTCWoYb3y9LH+6YBAqci8NQkYnHAV+WHC8VA==",
-        "dependencies": {
-          "Microsoft.JSInterop": "10.0.8"
-        }
       },
       "Microsoft.Orleans.Analyzers": {
         "type": "Transitive",
@@ -561,16 +438,6 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
-      "Mono.Cecil": {
-        "type": "Transitive",
-        "resolved": "0.11.6",
-        "contentHash": "f33RkDtZO8VlGXCtmQIviOtxgnUdym9xx/b1p9h91CRGOsJFxCFOFK1FDbVt1OCf1aWwYejUFa2MOQyFWTFjbA=="
-      },
       "System.ClientModel": {
         "type": "Transitive",
         "resolved": "1.9.0",
@@ -630,27 +497,10 @@
           "System.Composition.Runtime": "9.0.0"
         }
       },
-      "System.Configuration.ConfigurationManager": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "7T+m0kDSlIPTHIkPMIu6m6tV6qsMqJpvQWW2jIc2qi7sn40qxFo0q+7mEQAhMPXZHMKnWrnv47ntGlM/ejvw3g==",
-        "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Security.Permissions": "6.0.0"
-        }
-      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "10.0.3",
         "contentHash": "+bZnyzt0/vt4g3QSllhsRNGTpa09p7Juy5K8spcK73cOTOefu4+HoY89hZOgIOmzB5A4hqPyEDKnzra7KKnhZw=="
-      },
-      "System.Drawing.Common": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
-        "dependencies": {
-          "Microsoft.Win32.SystemEvents": "6.0.0"
-        }
       },
       "System.IO.Hashing": {
         "type": "Transitive",
@@ -661,44 +511,6 @@
         "type": "Transitive",
         "resolved": "10.0.3",
         "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
-      },
-      "System.Security.Permissions": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
-        "dependencies": {
-          "System.Windows.Extensions": "6.0.0"
-        }
-      },
-      "System.ValueTuple": {
-        "type": "Transitive",
-        "resolved": "4.6.1",
-        "contentHash": "+RJT4qaekpZ7DDLhf+LTjq+E48jieKiY9ulJ+BoxKmZblIJfIJT8Ufcaa/clQqnYvWs8jugfGSMu8ylS0caG0w=="
-      },
-      "System.Windows.Extensions": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
-        "dependencies": {
-          "System.Drawing.Common": "6.0.0"
-        }
-      },
-      "TngTech.ArchUnitNET": {
-        "type": "Transitive",
-        "resolved": "0.13.3",
-        "contentHash": "4+V+rJ1DC6f2mbwpVnSKwUnN8OhbZ+YC2HoFXYj4Skb+pbabaweu5cnscyXBiMlU97b5GvoOKzpUCn0RCTmWeg==",
-        "dependencies": {
-          "CycleDetection": "2.0.0",
-          "JetBrains.Annotations": "2025.2.2",
-          "Mono.Cecil": "0.11.6",
-          "Newtonsoft.Json": "13.0.4",
-          "System.ValueTuple": "4.6.1"
-        }
       },
       "xunit.abstractions": {
         "type": "Transitive",
@@ -740,29 +552,6 @@
           "xunit.extensibility.core": "[2.9.3]"
         }
       },
-      "Mississippi.Aqueduct.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Orleans.Sdk": "[10.1.0, )"
-        }
-      },
-      "Mississippi.Aqueduct.Gateway": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Microsoft.Orleans.Streaming": "[10.1.0, )",
-          "Mississippi.Aqueduct.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Aqueduct.Runtime": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Microsoft.Orleans.Server": "[10.1.0, )",
-          "Microsoft.Orleans.Streaming": "[10.1.0, )",
-          "Mississippi.Aqueduct.Abstractions": "[1.0.0, )"
-        }
-      },
       "Mississippi.Brooks.Abstractions": {
         "type": "Project",
         "dependencies": {
@@ -774,53 +563,6 @@
           "Microsoft.Orleans.Streaming": "[10.1.0, )"
         }
       },
-      "Mississippi.Brooks.Runtime": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Microsoft.Orleans.Streaming": "[10.1.0, )",
-          "Mississippi.Brooks.Abstractions": "[1.0.0, )",
-          "Mississippi.Brooks.Runtime.Storage.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Brooks.Runtime.Storage.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.0.8, )",
-          "Mississippi.Brooks.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Brooks.Runtime.Storage.Cosmos": {
-        "type": "Project",
-        "dependencies": {
-          "Azure.Storage.Blobs": "[12.28.0, )",
-          "Microsoft.Azure.Cosmos": "[3.60.0, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Options": "[10.0.8, )",
-          "Mississippi.Brooks.Runtime.Storage.Abstractions": "[1.0.0, )",
-          "Mississippi.Common.Abstractions": "[1.0.0, )",
-          "Mississippi.Common.Runtime.Storage.Cosmos": "[1.0.0, )",
-          "Newtonsoft.Json": "[13.0.4, )"
-        }
-      },
-      "Mississippi.Brooks.Serialization.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.0.8, )"
-        }
-      },
-      "Mississippi.Brooks.Serialization.Json": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Mississippi.Brooks.Serialization.Abstractions": "[1.0.0, )"
-        }
-      },
       "Mississippi.Common.Abstractions": {
         "type": "Project",
         "dependencies": {
@@ -828,163 +570,11 @@
           "Microsoft.Orleans.Sdk": "[10.1.0, )"
         }
       },
-      "Mississippi.Common.Runtime.Storage.Abstractions": {
-        "type": "Project"
-      },
-      "Mississippi.Common.Runtime.Storage.Cosmos": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Azure.Cosmos": "[3.60.0, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.0.8, )",
-          "Mississippi.Common.Runtime.Storage.Abstractions": "[1.0.0, )",
-          "Newtonsoft.Json": "[13.0.4, )"
-        }
-      },
-      "Mississippi.DomainModeling.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Options": "[10.0.8, )",
-          "Mississippi.Brooks.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.DomainModeling.Gateway": {
-        "type": "Project",
-        "dependencies": {
-          "Mississippi.Common.Abstractions": "[1.0.0, )",
-          "Mississippi.DomainModeling.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.DomainModeling.Runtime": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Microsoft.Orleans.Reminders": "[10.1.0, )",
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Mississippi.Brooks.Runtime": "[1.0.0, )",
-          "Mississippi.Brooks.Serialization.Abstractions": "[1.0.0, )",
-          "Mississippi.DomainModeling.Abstractions": "[1.0.0, )",
-          "Mississippi.Tributary.Abstractions": "[1.0.0, )",
-          "Mississippi.Tributary.Runtime": "[1.0.0, )"
-        }
-      },
-      "Mississippi.DomainModeling.TestHarness": {
-        "type": "Project",
-        "dependencies": {
-          "FluentAssertions": "[8.10.0, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.0.8, )",
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Mississippi.DomainModeling.Abstractions": "[1.0.0, )",
-          "Mississippi.Tributary.Abstractions": "[1.0.0, )",
-          "Moq": "[4.20.72, )"
-        }
-      },
-      "Mississippi.Inlet.Abstractions": {
-        "type": "Project"
-      },
-      "Mississippi.Inlet.Client": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.AspNetCore.Components.WebAssembly": "[10.0.8, )",
-          "Microsoft.AspNetCore.SignalR.Client": "[10.0.8, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Options": "[10.0.8, )",
-          "Mississippi.Inlet.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Client.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Gateway.Abstractions": "[1.0.0, )",
-          "Mississippi.Reservoir.Client": "[1.0.0, )",
-          "Mississippi.Reservoir.Core": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Inlet.Client.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Mississippi.Common.Abstractions": "[1.0.0, )",
-          "Mississippi.Reservoir.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Inlet.Gateway": {
-        "type": "Project",
-        "dependencies": {
-          "Mississippi.Aqueduct.Gateway": "[1.0.0, )",
-          "Mississippi.Inlet.Gateway.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Runtime": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Inlet.Gateway.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.0.8, )"
-        }
-      },
-      "Mississippi.Inlet.Generators.Abstractions": {
-        "type": "Project"
-      },
-      "Mississippi.Inlet.Runtime": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Microsoft.Orleans.Streaming": "[10.1.0, )",
-          "Mississippi.Aqueduct.Abstractions": "[1.0.0, )",
-          "Mississippi.Brooks.Abstractions": "[1.0.0, )",
-          "Mississippi.DomainModeling.Runtime": "[1.0.0, )",
-          "Mississippi.Inlet.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Gateway.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Generators.Abstractions": "[1.0.0, )",
-          "Mississippi.Inlet.Runtime.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Inlet.Runtime.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Mississippi.Inlet.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Reservoir.Abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )"
-        }
-      },
-      "Mississippi.Reservoir.Client": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.AspNetCore.Components": "[10.0.8, )",
-          "Microsoft.AspNetCore.Components.Web": "[10.0.8, )",
-          "Microsoft.AspNetCore.Components.WebAssembly": "[10.0.8, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
-          "Mississippi.Reservoir.Abstractions": "[1.0.0, )",
-          "Mississippi.Reservoir.Core": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Reservoir.Core": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Mississippi.Reservoir.Abstractions": "[1.0.0, )"
-        }
-      },
       "Mississippi.Tributary.Abstractions": {
         "type": "Project",
         "dependencies": {
           "Microsoft.Orleans.Sdk": "[10.1.0, )",
           "Mississippi.Brooks.Abstractions": "[1.0.0, )"
-        }
-      },
-      "Mississippi.Tributary.Runtime": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.0.8, )",
-          "Microsoft.Orleans.Sdk": "[10.1.0, )",
-          "Mississippi.Brooks.Runtime": "[1.0.0, )",
-          "Mississippi.Brooks.Serialization.Abstractions": "[1.0.0, )",
-          "Mississippi.Tributary.Abstractions": "[1.0.0, )",
-          "Mississippi.Tributary.Runtime.Storage.Abstractions": "[1.0.0, )"
         }
       },
       "Mississippi.Tributary.Runtime.Storage.Abstractions": {
@@ -1009,18 +599,6 @@
           "Mississippi.Tributary.Runtime.Storage.Abstractions": "[1.0.0, )"
         }
       },
-      "Mississippi.Tributary.Runtime.Storage.Cosmos": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.Azure.Cosmos": "[3.60.0, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.8, )",
-          "Microsoft.Extensions.Options": "[10.0.8, )",
-          "Mississippi.Common.Abstractions": "[1.0.0, )",
-          "Mississippi.Common.Runtime.Storage.Cosmos": "[1.0.0, )",
-          "Mississippi.Tributary.Runtime.Storage.Abstractions": "[1.0.0, )",
-          "Newtonsoft.Json": "[13.0.4, )"
-        }
-      },
       "Azure.Storage.Blobs": {
         "type": "CentralTransitive",
         "requested": "[12.28.0, )",
@@ -1036,70 +614,6 @@
         "requested": "[2.8.0, )",
         "resolved": "2.8.0",
         "contentHash": "RvabvAQV7u3FZcZL5UlRmFz3/T5nMl86GpChpRvHKRHbO+/I4LBcZ0xRqYnNfAh30gM+h/JkSBHEnbhl0zmGtA=="
-      },
-      "FluentAssertions": {
-        "type": "CentralTransitive",
-        "requested": "[8.10.0, )",
-        "resolved": "8.10.0",
-        "contentHash": "yGvv+xp0gHFgGwhQcGoDdKIrhLhPi3zYYWWLLHPMctr+G6PWD7QH8L4wqoa5WRZquPbfSV/cP1MraI7ppAHrWw=="
-      },
-      "Microsoft.AspNetCore.Components": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "307/ua6dEQ+XQBAVJf9I9OG1QIDmhReRMiNA/XCff54t+qP7ZhjJ8/tKsRZ5tBlgrGaRr6zLmMAS17j34eLAgA==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "10.0.8",
-          "Microsoft.AspNetCore.Components.Analyzers": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.Components.Web": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "r3SkaADmYqGAVrk2lhy+/kVsU2eBTRTXi0uCDppZX/VaX8m3ENtBd749XT8wGQyhfYr8MT6rC9WDXI1mmPHrGg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Components": "10.0.8",
-          "Microsoft.AspNetCore.Components.Forms": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8",
-          "Microsoft.JSInterop": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.Components.WebAssembly": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "/bxlPbfqxqgWOXHab7EUblZUzoqPIF0Wa6pm6CiwVlSWERLSH9dXPgexNINbaNqEt348XM97fCv0c9r7ef2DdQ==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Components.Web": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.Logging": "10.0.8",
-          "Microsoft.JSInterop.WebAssembly": "10.0.8"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Client": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "GC0SmIqE1b5Lqibt5mZ5yN7RtMKxwzaLvceSpo9f3GPZChCevLVLeAnxEhmNq79yYjXMK5K7TYdu7nVeENLinw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Connections.Client": "10.0.8",
-          "Microsoft.AspNetCore.SignalR.Client.Core": "10.0.8"
-        }
-      },
-      "Microsoft.Azure.Cosmos": {
-        "type": "CentralTransitive",
-        "requested": "[3.60.0, )",
-        "resolved": "3.60.0",
-        "contentHash": "v7ff0uqu1wSgtqkCjGywDCChzLZjC1xytH+0Dmq7IUwG2oaDpFrKioXTv3f+K8oCjnLDIxqrqe21CTY8kK7gVA==",
-        "dependencies": {
-          "Azure.Core": "1.44.1",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Microsoft.Bcl.HashCode": "1.1.0",
-          "System.Configuration.ConfigurationManager": "6.0.0"
-        }
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "CentralTransitive",
@@ -1159,8 +673,8 @@
       "Microsoft.Extensions.Features": {
         "type": "CentralTransitive",
         "requested": "[10.0.3, )",
-        "resolved": "10.0.8",
-        "contentHash": "pzn7prqSzxHmXIQw+yomgkEUMU5ZtE+WK/5syc8ob5rWrRaqb+JTt7GkW9AU9y6NMVNTEjV9vrJMfO+lUlcH8A=="
+        "resolved": "10.0.3",
+        "contentHash": "djFt1Jt+2uREWWVQiiA4ilYBDtHHY7nK08c5K8xBD9+XFNw3KDVprylrMkH08bZGK3ZHRAkS7JDV9srfLrcm/g=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",
@@ -1208,12 +722,12 @@
       "Microsoft.Extensions.Logging": {
         "type": "CentralTransitive",
         "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "K60JhWC2hN/Gi7TP68tBxSzk5ACWOs7lkmPzsfA8Bcf/IXTajujt2ORMf9rSMk1bsng6Lv4Y3fuxp3bm1+15ug==",
+        "resolved": "10.0.3",
+        "contentHash": "8D9Er1cGXNjNDIB+VLBNHn386L5ls2FoiG9a6o12gyn+GG3w6jdfUhzT8dtBnKcevE7/fsVA8MS3FBgFfClFtQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -1246,76 +760,6 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
           "Microsoft.Extensions.Options": "10.0.8",
           "Microsoft.Extensions.Primitives": "10.0.8"
-        }
-      },
-      "Microsoft.Orleans.Persistence.Memory": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.1.0",
-        "contentHash": "Y6CCdLa5uyKmN27Ci39VMLuFiGnGHsKlnJ2R7m6El4oKhp+/AI1q4YUxWo61i6vK++LU64oZl3L4jhEKGf6G8A==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.3",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "5.0.0",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
-          "Microsoft.Extensions.Configuration": "10.0.3",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
-          "Microsoft.Extensions.Configuration.Json": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.DependencyModel": "10.0.3",
-          "Microsoft.Extensions.Hosting": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging.Console": "10.0.3",
-          "Microsoft.Extensions.Logging.Debug": "10.0.3",
-          "Microsoft.Extensions.ObjectPool": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
-          "Microsoft.Orleans.Analyzers": "10.1.0",
-          "Microsoft.Orleans.CodeGenerator": "10.1.0",
-          "Microsoft.Orleans.Runtime": "10.1.0",
-          "Newtonsoft.Json": "13.0.4",
-          "System.IO.Hashing": "10.0.3",
-          "System.Memory.Data": "10.0.3"
-        }
-      },
-      "Microsoft.Orleans.Reminders": {
-        "type": "CentralTransitive",
-        "requested": "[10.1.0, )",
-        "resolved": "10.1.0",
-        "contentHash": "CoGEejDsn02aHk7xxdkONq5wrzezU5uhXq5YeRLMdrgBLTK5lmk4NuiJCIZ5l7qjKiMfn09jnzCEA5bnLZaZpA==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.3",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "5.0.0",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
-          "Microsoft.Extensions.Configuration": "10.0.3",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
-          "Microsoft.Extensions.Configuration.Json": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.DependencyModel": "10.0.3",
-          "Microsoft.Extensions.Hosting": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging.Console": "10.0.3",
-          "Microsoft.Extensions.Logging.Debug": "10.0.3",
-          "Microsoft.Extensions.ObjectPool": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
-          "Microsoft.Orleans.Analyzers": "10.1.0",
-          "Microsoft.Orleans.CodeGenerator": "10.1.0",
-          "Microsoft.Orleans.Core.Abstractions": "10.1.0",
-          "Microsoft.Orleans.Runtime": "10.1.0",
-          "Microsoft.Orleans.Sdk": "10.1.0",
-          "Newtonsoft.Json": "13.0.4",
-          "System.IO.Hashing": "10.0.3",
-          "System.Memory.Data": "10.0.3"
         }
       },
       "Microsoft.Orleans.Sdk": {
@@ -1359,40 +803,6 @@
         "contentHash": "+OqJ86TeiCN3ri+fNlymd7Q+LZBf+3F2Xdq+rngDc2q+vKF7dWP5L4H0ss3LHs07Otzm3lUGt8b2Co1eSvDI5A==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
-        }
-      },
-      "Microsoft.Orleans.Server": {
-        "type": "CentralTransitive",
-        "requested": "[10.1.0, )",
-        "resolved": "10.1.0",
-        "contentHash": "AU3JRBIaVTbK2agL/4qYvoofQTFx0djwk7KqW+1KZ8H4BDhQxcViOwGWqzH4V8An7a5ywsL164zRO7zTsumOGw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "10.0.3",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "5.0.0",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "5.0.0",
-          "Microsoft.Extensions.Configuration": "10.0.3",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
-          "Microsoft.Extensions.Configuration.Json": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.DependencyModel": "10.0.3",
-          "Microsoft.Extensions.Hosting": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging.Console": "10.0.3",
-          "Microsoft.Extensions.Logging.Debug": "10.0.3",
-          "Microsoft.Extensions.ObjectPool": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
-          "Microsoft.Orleans.Persistence.Memory": "10.1.0",
-          "Microsoft.Orleans.Runtime": "10.1.0",
-          "Microsoft.Orleans.Sdk": "10.1.0",
-          "Newtonsoft.Json": "13.0.4",
-          "System.IO.Hashing": "10.0.3",
-          "System.Memory.Data": "10.0.3"
         }
       },
       "Microsoft.Orleans.Streaming": {


### PR DESCRIPTION
# Add Tributary Azure Blob snapshot storage provider

Adds a first-class Azure Blob-backed snapshot storage provider for Tributary and switches the Spring sample to use Blob snapshots while keeping Brooks event streams on Cosmos.

## Business Value

This gives Mississippi applications a lower-friction snapshot storage option for Azure-hosted workloads that already use Blob Storage. Teams can keep event streams in Cosmos while storing snapshots in a dedicated Blob container, reducing coupling between event persistence and snapshot persistence.

**Key benefits:**

1. Adds an Azure Blob snapshot provider that follows the existing Tributary storage-provider seam.
2. Uses a JSON document format with schema metadata, opaque payload bytes, and optional gzip compression.
3. Demonstrates the provider in Spring using the existing Aspire Blob resource with a dedicated `snapshots` container.

## Common Use Cases

| Domain | Use Case | Example |
| --- | --- | --- |
| SaaS platforms | Separate event stream and snapshot persistence | Keep Brooks events in Cosmos while storing aggregate snapshots in Blob Storage. |
| Cost-sensitive services | Use Blob for larger snapshot payloads | Store infrequently read snapshot JSON documents in a dedicated Blob container. |
| Azure-hosted samples | Reuse an existing storage account safely | Spring reuses the Aspire `blobs` client but isolates snapshots in the `snapshots` container. |

## How It Works

### Overview

The provider registers against the existing `ISnapshotStorageProvider` abstraction. Snapshot writes create one JSON Blob per snapshot version under a hashed stream prefix, and reads validate the persisted document before returning a `SnapshotEnvelope`.

```text
Spring.Runtime
  ├─ Brooks events -> Cosmos provider (unchanged)
  └─ Tributary snapshots -> Blob provider
        ├─ keyed BlobServiceClient: mississippi-blob-snapshots
        ├─ dedicated container: snapshots
        ├─ JSON document wrapper: schemaVersion, stream key, version, compression, payload
        └─ optional gzip payload compression
```

### Key Design Decisions

- **JSON wrapper over opaque payload bytes**: preserves the existing snapshot envelope contract while making storage inspectable and versioned.
- **Dedicated `snapshots` container**: allows one Blob account to serve multiple concerns without mixing snapshot objects with other Blob usage.
- **Hashed stream prefixes**: avoids leaking raw key components into Blob paths and keeps names safe for Azure Blob naming rules.
- **Startup initialization**: a hosted service creates the container if it does not already exist.
- **Bounded gzip decompression**: protects reads from expanding beyond the configured maximum uncompressed payload size.

### Code Example

```csharp
builder.Services.AddBlobSnapshotStorageProvider(options =>
{
    options.EnableCompression = true;
});
```

Spring also forwards the Aspire `blobs` client to `SnapshotBlobDefaults.BlobServiceClientServiceKey` so the provider can reuse the same storage account with its own `snapshots` container.

## Observability

Spring snapshot observability changes from the Cosmos snapshot meter to the Blob snapshot meter.

| Metric/Log | Type | Description |
| --- | --- | --- |
| `Mississippi.Storage.Blob.Snapshots` | Meter | Blob snapshot delete, prune, read, write, size, and duration metrics. |
| Provider logger extensions | Logs | Source-generated diagnostics for provider, repository, and startup initialization behavior. |

Dashboard owners should update any Spring snapshot dashboards that referenced `Mississippi.Storage.Snapshots` to use `Mississippi.Storage.Blob.Snapshots`.

## Files Changed

### New Files

| File | Purpose |
| --- | --- |
| `docs/Docusaurus/docs/tributary/storage-providers/blob-storage.md` | Documents Blob snapshot provider registration, storage format, compression, lifecycle, diagnostics, and Spring usage. |
| `src/Tributary.Runtime.Storage.Blobs/Tributary.Runtime.Storage.Blobs.csproj` | New provider project. |
| `src/Tributary.Runtime.Storage.Blobs/Diagnostics/SnapshotBlobStorageMetrics.cs` | Blob snapshot metrics. |
| `src/Tributary.Runtime.Storage.Blobs/ISnapshotBlobOperations.cs` | Azure SDK seam for deterministic tests. |
| `src/Tributary.Runtime.Storage.Blobs/ISnapshotBlobRepository.cs` | Internal repository seam. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobContainerInitializer.cs` | Startup container initialization hosted service. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobContainerInitializerLoggerExtensions.cs` | Source-generated initializer logging. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobDefaults.cs` | Provider constants, service keys, default container, and default payload limit. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageOptions.cs` | Provider options. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageOptionsValidator.cs` | Startup options validation. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProvider.cs` | Public snapshot storage provider implementation. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProviderLoggerExtensions.cs` | Source-generated provider logging. |
| `src/Tributary.Runtime.Storage.Blobs/SnapshotBlobStorageProviderRegistrations.cs` | DI registration extensions and keyed Blob clients. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobCompression.cs` | Optional gzip compression and bounded decompression. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobCompressionResult.cs` | Compression result value object. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobDocument.cs` | JSON document schema. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobDocumentSerializer.cs` | JSON serialization/deserialization. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobOperations.cs` | Azure Blob SDK adapter. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobPath.cs` | Durable Blob path construction and version parsing. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobRepository.cs` | Read/write/delete/prune semantics and validation. |
| `src/Tributary.Runtime.Storage.Blobs/Storage/SnapshotBlobRepositoryLoggerExtensions.cs` | Source-generated repository logging. |
| `src/Tributary.Runtime.Storage.Blobs/packages.lock.json` | Lock file for the provider project. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/Tributary.Runtime.Storage.Blobs.L0Tests.csproj` | New L0 test project. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/Diagnostics/SnapshotBlobStorageMetricsTests.cs` | Metrics tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobCompressionTests.cs` | Compression tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobDocumentTests.cs` | JSON document serialization tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobNameTests.cs` | Blob naming/path tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobRepositoryTests.cs` | Repository behavior and validation tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageOptionsTests.cs` | Defaults and options validation tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageProviderRegistrationsTests.cs` | DI registration tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/SnapshotBlobStorageProviderTests.cs` | Provider delegation tests. |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/packages.lock.json` | Lock file for the test project. |

### Modified Files

| File | Change |
| --- | --- |
| `docs/Docusaurus/docs/tributary/storage-providers/index.md` | Adds Azure Blob snapshots to the storage provider overview and notes Spring’s split between Blob snapshots and Cosmos events. |
| `mississippi.slnx` | Includes the new provider and L0 test projects. |
| `samples/Spring/Spring.AppHost/Program.cs` | Clarifies existing Blob resource comments for locking and snapshots. |
| `samples/Spring/Spring.Runtime/Program.cs` | Switches Spring snapshots to Blob, enables compression, forwards the keyed Blob client, and registers Blob snapshot metrics. |
| `samples/Spring/Spring.Runtime/Spring.Runtime.csproj` | References the new Blob provider project. |
| `samples/Spring/Spring.Runtime/packages.lock.json` | Refreshes lock file after adding the project reference. |
| `tests/Architecture.L0Tests/Architecture.L0Tests.csproj` | Adds the provider assembly to architecture validation. |
| `tests/Architecture.L0Tests/packages.lock.json` | Refreshes architecture test lock file. |

### New Tests

| File | Coverage |
| --- | --- |
| `tests/Tributary.Runtime.Storage.Blobs.L0Tests/**` | 51 deterministic L0 tests covering registration, options, paths, JSON schema, compression, repository validation, provider delegation, and metrics. |

## Quality Gates

- [x] Blob provider L0 tests passed: `51/51`.
- [x] Spring runtime build passed with warnings as errors.
- [x] Architecture L0 tests passed: `36/36`.
- [x] Docusaurus production build passed.
- [x] Full `pwsh .\go.ps1 -IncludeMutation` completed successfully with exit code `0`.
- [x] Final zero-warning builds passed for `mississippi.slnx` and `samples.slnx`.

Note: the mutation phase emitted broad Stryker project-level warnings while repository automation still completed successfully, reported acceptable mutation quality, and the full pipeline exited `0`.

## Migration Notes

No breaking framework API change is intended.

Spring sample behavior changes:

- Snapshot storage moves from Cosmos snapshots to Azure Blob snapshots.
- Brooks event stream storage remains on Cosmos.
- Snapshot metrics now use `Mississippi.Storage.Blob.Snapshots` instead of `Mississippi.Storage.Snapshots`.

Existing applications can opt into the provider by registering a keyed `BlobServiceClient` and calling `AddBlobSnapshotStorageProvider`.

## Related Issues

N/A
