### PR TITLE
Roll back saga resume reminder when aggregate event append fails +semver: fix

### DIFF
--- a/src/DomainModeling.Runtime/AggregateGrainLoggerExtensions.cs
+++ b/src/DomainModeling.Runtime/AggregateGrainLoggerExtensions.cs
@@ -295,6 +295,40 @@ internal static partial class AggregateGrainLoggerExtensions
     );
 
     /// <summary>
+    ///     Logs when unregistering a newly created saga reminder fails after a failed append.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="reminderName">The reminder name.</param>
+    /// <param name="aggregateKey">The aggregate key.</param>
+    /// <param name="exception">The exception thrown during reminder rollback.</param>
+    [LoggerMessage(
+        25,
+        LogLevel.Error,
+        "Failed to unregister reminder {ReminderName} for aggregate {AggregateKey} after a failed event append; the reminder may fire without committed saga events")]
+    public static partial void SagaReminderRollbackFailed(
+        this ILogger logger,
+        string reminderName,
+        string aggregateKey,
+        Exception exception
+    );
+
+    /// <summary>
+    ///     Logs when a newly created saga reminder is rolled back because the event append failed.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="reminderName">The reminder name.</param>
+    /// <param name="aggregateKey">The aggregate key.</param>
+    [LoggerMessage(
+        24,
+        LogLevel.Warning,
+        "Rolling back reminder {ReminderName} for aggregate {AggregateKey} because the event append failed before committing")]
+    public static partial void SagaReminderRollingBackAfterFailedAppend(
+        this ILogger logger,
+        string reminderName,
+        string aggregateKey
+    );
+
+    /// <summary>
     ///     Logs when a reminder tick is skipped because saga work is already in progress.
     /// </summary>
     /// <param name="logger">The logger.</param>
@@ -305,6 +339,22 @@ internal static partial class AggregateGrainLoggerExtensions
         LogLevel.Debug,
         "Skipping reminder {ReminderName} for aggregate {AggregateKey} because saga work is already active")]
     public static partial void SagaReminderSkippedAlreadyActive(
+        this ILogger logger,
+        string reminderName,
+        string aggregateKey
+    );
+
+    /// <summary>
+    ///     Logs when a reminder fires for a saga that never started and is unregistered as stale.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="reminderName">The reminder name.</param>
+    /// <param name="aggregateKey">The aggregate key.</param>
+    [LoggerMessage(
+        26,
+        LogLevel.Information,
+        "Reminder {ReminderName} found saga phase NotStarted for aggregate {AggregateKey}; unregistering stale reminder instead of recovering")]
+    public static partial void SagaReminderStaleNotStarted(
         this ILogger logger,
         string reminderName,
         string aggregateKey

--- a/src/DomainModeling.Runtime/GenericAggregateGrain.cs
+++ b/src/DomainModeling.Runtime/GenericAggregateGrain.cs
@@ -199,6 +199,11 @@ internal sealed class GenericAggregateGrain<TAggregate>
     ) =>
         ex is OutOfMemoryException or StackOverflowException or ThreadInterruptedException;
 
+    private static bool IsSagaPhaseNotStarted(
+        TAggregate aggregate
+    ) =>
+        aggregate is ISagaState sagaState && (sagaState.Phase == SagaPhase.NotStarted);
+
     private static bool IsTerminalSagaPhase(
         TAggregate aggregate
     ) =>
@@ -324,6 +329,15 @@ internal sealed class GenericAggregateGrain<TAggregate>
             if (currentState is not null && IsTerminalSagaPhase(currentState))
             {
                 Logger.SagaReminderTerminalState(brookKey, ((ISagaState)currentState).Phase, reminderName);
+                await UnregisterSagaReminderIfExistsAsync();
+                return;
+            }
+
+            if (currentState is not null && IsSagaPhaseNotStarted(currentState))
+            {
+                // No saga lifecycle event ever committed, so the reminder is stale (for example, it
+                // was registered for an append that failed). Recovery would be bogus; drop it.
+                Logger.SagaReminderStaleNotStarted(reminderName, brookKey);
                 await UnregisterSagaReminderIfExistsAsync();
                 return;
             }
@@ -677,6 +691,23 @@ internal sealed class GenericAggregateGrain<TAggregate>
         return position;
     }
 
+    /// <summary>
+    ///     Persists the supplied events and dispatches synchronous and fire-and-forget effects.
+    /// </summary>
+    /// <param name="events">The domain events produced by the command handler.</param>
+    /// <param name="currentPosition">The brook position before the append.</param>
+    /// <param name="commandTypeName">The command type name, for diagnostics.</param>
+    /// <param name="aggregateKey">The aggregate key, for diagnostics.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    ///     <para>
+    ///         The saga resume reminder is registered before the append so committed saga lifecycle
+    ///         events are never left without a durable wake-up safety net. If the append fails, a
+    ///         reminder that was newly created for this append is rolled back so it cannot fire later
+    ///         and attempt recovery for events that never committed. A reminder that already existed
+    ///         before this command is left in place because it guards earlier committed saga work.
+    ///     </para>
+    /// </remarks>
     private async Task PersistEventsAndDispatchEffectsAsync(
         IReadOnlyList<object> events,
         BrookPosition currentPosition,
@@ -686,10 +717,19 @@ internal sealed class GenericAggregateGrain<TAggregate>
     )
     {
         ImmutableArray<BrookEvent> brookEvents = BrookEventConverter.ToStorageEvents(brookKey, events);
-        await RegisterSagaReminderIfNeededAsync(events);
+        bool reminderNewlyRegistered = await RegisterSagaReminderIfNeededAsync(events);
         BrookPosition? expectedCursorPosition = currentPosition.NotSet ? null : currentPosition;
-        await BrookGrainFactory.GetBrookWriterGrain(brookKey)
-            .AppendEventsAsync(brookEvents, expectedCursorPosition, cancellationToken);
+        try
+        {
+            await BrookGrainFactory.GetBrookWriterGrain(brookKey)
+                .AppendEventsAsync(brookEvents, expectedCursorPosition, cancellationToken);
+        }
+        catch (Exception appendException) when (reminderNewlyRegistered && !IsCriticalException(appendException))
+        {
+            await RollBackSagaReminderAfterFailedAppendAsync();
+            throw;
+        }
+
         lastKnownPosition = new BrookPosition(currentPosition.Value + brookEvents.Length);
         await DispatchSynchronousEffectsAsync(
             events,
@@ -861,21 +901,32 @@ internal sealed class GenericAggregateGrain<TAggregate>
             confirmedPosition);
     }
 
-    private async Task RegisterSagaReminderIfNeededAsync(
+    /// <summary>
+    ///     Registers or updates the saga resume reminder when the events require a durable wake-up.
+    /// </summary>
+    /// <param name="events">The domain events about to be appended.</param>
+    /// <returns>
+    ///     <see langword="true" /> when this call created a reminder that did not previously exist;
+    ///     <see langword="false" /> when no registration was needed or a reminder already existed.
+    ///     Callers use this to decide whether a failed append should roll the reminder back.
+    /// </returns>
+    private async Task<bool> RegisterSagaReminderIfNeededAsync(
         IReadOnlyList<object> events
     )
     {
         if (!IsSagaAggregateType || !events.Any(SagaLifecycleEventClassifier.IsOrchestrationLifecycleEvent))
         {
-            return;
+            return false;
         }
 
+        IGrainReminder? existingReminder = await SagaReminderRegistry.GetReminderAsync(this, SagaResumeReminderName);
         Logger.SagaReminderRegistering(SagaResumeReminderName, brookKey);
         await SagaReminderRegistry.RegisterOrUpdateAsync(
             this,
             SagaResumeReminderName,
             SagaResumeReminderDueTime,
             SagaResumeReminderPeriod);
+        return existingReminder is null;
     }
 
     private async Task<bool> ReplaySagaBoundaryAsync(
@@ -892,6 +943,27 @@ internal sealed class GenericAggregateGrain<TAggregate>
 
         await DispatchEffectsAsync([boundaryEvent], currentState, brookKey, eventPosition, cancellationToken);
         return true;
+    }
+
+    /// <summary>
+    ///     Best-effort removal of a saga reminder that was registered for an append that never committed.
+    /// </summary>
+    /// <remarks>
+    ///     Rollback failures are logged and swallowed so the original append exception propagates to
+    ///     the caller. A leaked reminder is handled defensively by <see cref="ReceiveReminder" />,
+    ///     which unregisters stale reminders instead of running recovery for uncommitted work.
+    /// </remarks>
+    private async Task RollBackSagaReminderAfterFailedAppendAsync()
+    {
+        Logger.SagaReminderRollingBackAfterFailedAppend(SagaResumeReminderName, brookKey);
+        try
+        {
+            await UnregisterSagaReminderIfExistsAsync();
+        }
+        catch (Exception rollbackException) when (!IsCriticalException(rollbackException))
+        {
+            Logger.SagaReminderRollbackFailed(SagaResumeReminderName, brookKey, rollbackException);
+        }
     }
 
     private async Task UnregisterSagaReminderIfExistsAsync()

--- a/tests/DomainModeling.Runtime.L0Tests/GenericAggregateGrainSagaReminderTests.cs
+++ b/tests/DomainModeling.Runtime.L0Tests/GenericAggregateGrainSagaReminderTests.cs
@@ -56,6 +56,7 @@ public sealed class GenericAggregateGrainSagaReminderTests
         Mock<IBrookWriterGrain>? writerMock = null,
         Mock<ISnapshotGrainFactory>? snapshotFactoryMock = null,
         Mock<IBrookEventConverter>? brookEventConverterMock = null,
+        Mock<ILogger<GenericAggregateGrain<TestSagaState>>>? loggerMock = null,
         Mock<ISagaReminderRegistry>? reminderRegistryMock = null,
         Mock<IRootEventEffect<TestSagaState>>? rootEventEffectMock = null,
         TimeProvider? timeProvider = null
@@ -70,6 +71,7 @@ public sealed class GenericAggregateGrainSagaReminderTests
             brookEventConverterMock: brookEventConverterMock,
             rootCommandHandlerMock: rootCommandHandlerMock,
             snapshotFactoryMock: snapshotFactoryMock,
+            loggerMock: loggerMock,
             reminderRegistryMock: reminderRegistryMock,
             rootEventEffectMock: rootEventEffectMock,
             timeProvider: timeProvider);
@@ -337,6 +339,40 @@ public sealed class GenericAggregateGrainSagaReminderTests
     }
 
     /// <summary>
+    ///     Leaves the reminder registry untouched when appending non-lifecycle events fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ExecuteAsyncDoesNotRollBackReminderWhenNonLifecycleAppendFails()
+    {
+        Mock<ISagaReminderRegistry> reminderRegistryMock = new();
+        Mock<IBrookWriterGrain> writerMock = new();
+        writerMock.Setup(w => w.AppendEventsAsync(
+                It.IsAny<ImmutableArray<BrookEvent>>(),
+                It.IsAny<BrookPosition?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("append failed"));
+        GenericAggregateGrain<TestSagaState> grain = await CreateActivatedSagaGrainAsync(
+            [new TestSagaInput("transfer-9")],
+            writerMock: writerMock,
+            reminderRegistryMock: reminderRegistryMock);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => grain.ExecuteAsync(
+            new TestSagaCommand(),
+            CancellationToken.None));
+        reminderRegistryMock.Verify(r => r.GetReminderAsync(It.IsAny<IGrainBase>(), It.IsAny<string>()), Times.Never);
+        reminderRegistryMock.Verify(
+            r => r.RegisterOrUpdateAsync(
+                It.IsAny<IGrainBase>(),
+                It.IsAny<string>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<TimeSpan>()),
+            Times.Never);
+        reminderRegistryMock.Verify(
+            r => r.UnregisterAsync(It.IsAny<IGrainBase>(), It.IsAny<IGrainReminder>()),
+            Times.Never);
+    }
+
+    /// <summary>
     ///     Does not update the reminder inside yielded-effect persistence.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -402,6 +438,53 @@ public sealed class GenericAggregateGrainSagaReminderTests
     }
 
     /// <summary>
+    ///     Keeps a pre-existing saga reminder registered when the event append fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ExecuteAsyncKeepsPreExistingReminderWhenAppendFails()
+    {
+        Mock<IGrainReminder> grainReminderMock = new();
+        Mock<ISagaReminderRegistry> reminderRegistryMock = CreateReminderRegistryMock();
+        reminderRegistryMock.Setup(r => r.GetReminderAsync(It.IsAny<IGrainBase>(), SagaReminderName))
+            .ReturnsAsync(grainReminderMock.Object);
+        Mock<IBrookWriterGrain> writerMock = new();
+        writerMock.Setup(w => w.AppendEventsAsync(
+                It.IsAny<ImmutableArray<BrookEvent>>(),
+                It.IsAny<BrookPosition?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("append failed"));
+        GenericAggregateGrain<TestSagaState> grain = await CreateActivatedSagaGrainAsync(
+            [CreateStartedEvent()],
+            writerMock: writerMock,
+            reminderRegistryMock: reminderRegistryMock);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => grain.ExecuteAsync(
+            new TestSagaCommand(),
+            CancellationToken.None));
+        reminderRegistryMock.Verify(
+            r => r.UnregisterAsync(It.IsAny<IGrainBase>(), It.IsAny<IGrainReminder>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    ///     Registers the saga reminder when lifecycle events are mixed with other events.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ExecuteAsyncRegistersReminderWhenBatchMixesLifecycleAndOtherEvents()
+    {
+        Mock<ISagaReminderRegistry> reminderRegistryMock = CreateReminderRegistryMock();
+        GenericAggregateGrain<TestSagaState> grain = await CreateActivatedSagaGrainAsync(
+            [new TestSagaInput("transfer-9"), CreateStartedEvent()],
+            reminderRegistryMock: reminderRegistryMock);
+        OperationResult result = await grain.ExecuteAsync(new TestSagaCommand(), CancellationToken.None);
+        Assert.True(result.Success);
+        reminderRegistryMock.Verify(
+            r => r.RegisterOrUpdateAsync(grain, SagaReminderName, It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>()),
+            Times.Once);
+    }
+
+    /// <summary>
     ///     Registers the deterministic saga reminder before appending resumable lifecycle events.
     /// </summary>
     /// <param name="eventKind">The saga lifecycle event kind.</param>
@@ -436,6 +519,109 @@ public sealed class GenericAggregateGrainSagaReminderTests
         OperationResult result = await grain.ExecuteAsync(new TestSagaCommand(), CancellationToken.None);
         Assert.True(result.Success);
         Assert.Equal(["reminder", "append"], calls);
+    }
+
+    /// <summary>
+    ///     Surfaces the append failure even when rolling back the newly created reminder also fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ExecuteAsyncRethrowsAppendFailureWhenReminderRollbackFails()
+    {
+        Mock<IGrainReminder> grainReminderMock = new();
+        IGrainReminder? registeredReminder = null;
+        Mock<ILogger<GenericAggregateGrain<TestSagaState>>> loggerMock = new();
+        loggerMock.Setup(l => l.IsEnabled(LogLevel.Error)).Returns(true);
+        Mock<ISagaReminderRegistry> reminderRegistryMock = new();
+        reminderRegistryMock.Setup(r => r.GetReminderAsync(It.IsAny<IGrainBase>(), SagaReminderName))
+            .ReturnsAsync(() => registeredReminder);
+        reminderRegistryMock.Setup(r => r.RegisterOrUpdateAsync(
+                It.IsAny<IGrainBase>(),
+                SagaReminderName,
+                It.IsAny<TimeSpan>(),
+                It.IsAny<TimeSpan>()))
+            .Callback(() => registeredReminder = grainReminderMock.Object)
+            .Returns(Task.CompletedTask);
+        reminderRegistryMock.Setup(r => r.UnregisterAsync(It.IsAny<IGrainBase>(), grainReminderMock.Object))
+            .ThrowsAsync(new TimeoutException("reminder registry unavailable"));
+        Mock<IBrookWriterGrain> writerMock = new();
+        writerMock.Setup(w => w.AppendEventsAsync(
+                It.IsAny<ImmutableArray<BrookEvent>>(),
+                It.IsAny<BrookPosition?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("append failed"));
+        GenericAggregateGrain<TestSagaState> grain = await CreateActivatedSagaGrainAsync(
+            [CreateStartedEvent()],
+            writerMock: writerMock,
+            loggerMock: loggerMock,
+            reminderRegistryMock: reminderRegistryMock);
+        InvalidOperationException thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            grain.ExecuteAsync(new TestSagaCommand(), CancellationToken.None));
+        Assert.Equal("append failed", thrown.Message);
+        reminderRegistryMock.Verify(
+            r => r.UnregisterAsync(It.IsAny<IGrainBase>(), grainReminderMock.Object),
+            Times.Once);
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.Is<EventId>(id => id.Id == 25),
+                It.IsAny<It.IsAnyType>(),
+                It.Is<Exception>(ex => ex is TimeoutException),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    ///     Unregisters a reminder created for the current append when the append fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ExecuteAsyncUnregistersNewlyRegisteredReminderWhenAppendFails()
+    {
+        Mock<IGrainReminder> grainReminderMock = new();
+        IGrainReminder? registeredReminder = null;
+        Mock<ILogger<GenericAggregateGrain<TestSagaState>>> loggerMock = new();
+        loggerMock.Setup(l => l.IsEnabled(LogLevel.Warning)).Returns(true);
+        Mock<ISagaReminderRegistry> reminderRegistryMock = new();
+        reminderRegistryMock.Setup(r => r.GetReminderAsync(It.IsAny<IGrainBase>(), SagaReminderName))
+            .ReturnsAsync(() => registeredReminder);
+        reminderRegistryMock.Setup(r => r.RegisterOrUpdateAsync(
+                It.IsAny<IGrainBase>(),
+                SagaReminderName,
+                It.IsAny<TimeSpan>(),
+                It.IsAny<TimeSpan>()))
+            .Callback(() => registeredReminder = grainReminderMock.Object)
+            .Returns(Task.CompletedTask);
+        reminderRegistryMock.Setup(r => r.UnregisterAsync(It.IsAny<IGrainBase>(), grainReminderMock.Object))
+            .Callback(() => registeredReminder = null)
+            .Returns(Task.CompletedTask);
+        Mock<IBrookWriterGrain> writerMock = new();
+        writerMock.Setup(w => w.AppendEventsAsync(
+                It.IsAny<ImmutableArray<BrookEvent>>(),
+                It.IsAny<BrookPosition?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("append failed"));
+        GenericAggregateGrain<TestSagaState> grain = await CreateActivatedSagaGrainAsync(
+            [CreateStartedEvent()],
+            writerMock: writerMock,
+            loggerMock: loggerMock,
+            reminderRegistryMock: reminderRegistryMock);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => grain.ExecuteAsync(
+            new TestSagaCommand(),
+            CancellationToken.None));
+        reminderRegistryMock.Verify(
+            r => r.RegisterOrUpdateAsync(grain, SagaReminderName, It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>()),
+            Times.Once);
+        reminderRegistryMock.Verify(r => r.UnregisterAsync(grain, grainReminderMock.Object), Times.Once);
+        Assert.Null(registeredReminder);
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.Is<EventId>(id => id.Id == 24),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     /// <summary>
@@ -779,6 +965,64 @@ public sealed class GenericAggregateGrainSagaReminderTests
             reminderRegistryMock: reminderRegistryMock);
         await grain.ReceiveReminder(SagaReminderName, default);
         reminderRegistryMock.Verify(r => r.UnregisterAsync(grain, grainReminderMock.Object), Times.Once);
+        readerMock.Verify(
+            r => r.ReadEventsBatchAsync(
+                It.IsAny<BrookPosition?>(),
+                It.IsAny<BrookPosition?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        writerMock.Verify(
+            w => w.AppendEventsAsync(
+                It.IsAny<ImmutableArray<BrookEvent>>(),
+                It.IsAny<BrookPosition?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    ///     Unregisters a stale reminder without recovery when the saga phase is NotStarted.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ReceiveReminderUnregistersWhenSagaPhaseIsNotStarted()
+    {
+        Mock<IBrookCursorGrain> cursorMock = new();
+        cursorMock.Setup(c => c.GetLatestPositionConfirmedAsync()).ReturnsAsync(new BrookPosition(8));
+        Mock<IGrainReminder> grainReminderMock = new();
+        Mock<ILogger<GenericAggregateGrain<TestSagaState>>> loggerMock = new();
+        loggerMock.Setup(l => l.IsEnabled(LogLevel.Information)).Returns(true);
+        Mock<ISagaReminderRegistry> reminderRegistryMock = new();
+        reminderRegistryMock.Setup(r => r.GetReminderAsync(It.IsAny<IGrainBase>(), SagaReminderName))
+            .ReturnsAsync(grainReminderMock.Object);
+        Mock<IBrookReaderGrain> readerMock = new();
+        Mock<IBrookWriterGrain> writerMock = new();
+        Mock<ISnapshotCacheGrain<TestSagaState>> snapshotCacheMock = new();
+        snapshotCacheMock.Setup(s => s.GetStateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new TestSagaState
+                {
+                    Phase = SagaPhase.NotStarted,
+                });
+        Mock<ISnapshotGrainFactory> snapshotFactoryMock = new();
+        snapshotFactoryMock.Setup(f => f.GetSnapshotCacheGrain<TestSagaState>(It.IsAny<SnapshotKey>()))
+            .Returns(snapshotCacheMock.Object);
+        GenericAggregateGrain<TestSagaState> grain = await CreateActivatedSagaGrainAsync(
+            cursorMock: cursorMock,
+            readerMock: readerMock,
+            writerMock: writerMock,
+            snapshotFactoryMock: snapshotFactoryMock,
+            loggerMock: loggerMock,
+            reminderRegistryMock: reminderRegistryMock);
+        await grain.ReceiveReminder(SagaReminderName, default);
+        reminderRegistryMock.Verify(r => r.UnregisterAsync(grain, grainReminderMock.Object), Times.Once);
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.Is<EventId>(id => id.Id == 26),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
         readerMock.Verify(
             r => r.ReadEventsBatchAsync(
                 It.IsAny<BrookPosition?>(),


### PR DESCRIPTION
# Roll back saga resume reminder when aggregate event append fails

## Business Value

`GenericAggregateGrain` registers a durable saga resume reminder *before* appending saga lifecycle events to the brook, so committed events are never left without a wake-up safety net. However, when the append itself failed, the already-registered reminder leaked: it would later fire against a stream containing **no committed saga lifecycle events**, and the recovery path would durably append a bogus `SagaFailed` event (`SAGA_RECOVERY_UNSAFE_TAIL`). That is silent, durable state corruption — a saga that never started gets recorded as failed.

**Key benefits:**

1. **No durable corruption** — a transient append failure can no longer manufacture a phantom `SagaFailed` event on an otherwise-empty saga stream.
2. **Crash-safe defense in depth** — even if the process dies between reminder registration and append (where no rollback can run), the reminder path now detects the stale reminder and removes it benignly.
3. **Preserved recovery guarantees** — the intentional register-before-append ordering is untouched, so successfully committed saga work always keeps its durable wake-up.

## Common Use Cases

| Domain | Use Case | Example |
|--------|----------|---------|
| Payments | Money transfer saga start fails on optimistic-concurrency conflict | Reminder is rolled back; no phantom `SagaFailed` is written for a transfer that never began |
| Order fulfilment | Brook storage throttled (429) during saga step-completed append | Reminder created for that append is unregistered; the pre-existing reminder from earlier committed steps is kept |
| Any saga host | Silo crashes between reminder registration and append | On the next reminder tick, phase `NotStarted` is detected and the stale reminder is dropped without touching the stream |

## How It Works

### Overview

```mermaid
sequenceDiagram
    participant G as GenericAggregateGrain
    participant R as SagaReminderRegistry
    participant B as BrookWriterGrain
    G->>R: GetReminderAsync (was one already registered?)
    G->>R: RegisterOrUpdateAsync (before append, by design)
    G->>B: AppendEventsAsync
    alt Append succeeds
        G->>G: dispatch effects (reminder stays: designed recovery net)
    else Append fails
        alt Reminder newly created for this append
            G->>R: UnregisterAsync (best-effort rollback, logged)
        else Reminder pre-existed (earlier committed work)
            G->>G: keep reminder (it protects committed events)
        end
        G-->>G: rethrow original append exception
    end
```

Defense in depth: when a reminder fires and the saga snapshot phase is `NotStarted`, no `SagaStartedEvent` was ever committed, so the reminder is definitionally stale. `ReceiveReminder` now unregisters it and returns instead of running recovery (which previously appended `SagaFailed`).

### Key Design Decisions

- **Keep register-before-append ordering**: it is intentional (and test-asserted) so committed lifecycle events are never left without a durable wake-up. The fix compensates on failure instead of reordering.
- **Ownership-aware rollback**: `RegisterSagaReminderIfNeededAsync` now returns whether it *newly created* the reminder. Only a reminder created for the failed append is rolled back; a pre-existing reminder belongs to earlier committed saga work and must survive.
- **Rollback never masks the append failure**: unregistration is best-effort; if it throws, the error is logged (event id 25) and the original append exception still propagates.
- **`NotStarted` invariant guard in `ReceiveReminder`**: covers the crash window where the exception-path rollback cannot run. A reminder firing with phase `NotStarted` is removed benignly — recovery would be provably bogus.
- **Scenario 2 of the issue (append succeeds, effect dispatch fails) is intentionally unchanged**: the reminder staying registered there *is* the designed recovery mechanism.

## Observability

| Metric/Log | Type | Description |
|------------|------|-------------|
| `SagaReminderRollingBackAfterFailedAppend` (id 24) | Log/Warning | Reminder newly created for a failed append is being rolled back |
| `SagaReminderRollbackFailed` (id 25) | Log/Error | Rollback unregistration failed; reminder may leak (handled by the `NotStarted` guard) |
| `SagaReminderStaleNotStarted` (id 26) | Log/Information | Reminder fired with phase `NotStarted`; unregistered without recovery |

## Files Changed

### Modified Files

| File | Change |
|------|--------|
| `src/DomainModeling.Runtime/GenericAggregateGrain.cs` | Ownership-aware reminder rollback on append failure; `NotStarted` stale-reminder guard in `ReceiveReminder`; XML docs on the compensation contract |
| `src/DomainModeling.Runtime/AggregateGrainLoggerExtensions.cs` | New `[LoggerMessage]` events 24 (Warning), 25 (Error), 26 (Information) |

### New Tests

| File | Coverage |
|------|----------|
| `tests/DomainModeling.Runtime.L0Tests/GenericAggregateGrainSagaReminderTests.cs` | Newly created reminder is unregistered on append failure (log 24 verified); pre-existing reminder survives append failure; append exception propagates even when rollback fails (log 25 verified); `ReceiveReminder` drops stale `NotStarted` reminder without reading/appending (log 26 verified); registry untouched when non-lifecycle append fails; mixed lifecycle/non-lifecycle batch still registers |

## Quality Gates

- [x] Build passes with zero warnings (`build-mississippi-solution.ps1`, targeted `-warnaserror` builds)
- [x] All existing tests pass (343/343 in `DomainModeling.Runtime.L0Tests`)
- [x] New tests added for new functionality (6 new tests)
- [x] ReSharper/StyleCop cleanup clean (`clean-up-targeted.ps1`)
- [x] Mutation testing ran to completion: score 51.91% (up from 51.06% baseline); **all mutants in changed code killed** (verified via Stryker report line cross-reference)
- [x] Coverage on changed code: 100%

## Migration Notes

None — no public API changes. `RegisterSagaReminderIfNeededAsync` is a private method; its return-type change is internal to the grain.

## Related Issues

- Fixes #486